### PR TITLE
Build Chinese tutor MVP with FastAPI backend and Expo React Native client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Python
+backend/.venv/
+__pycache__/
+*.pyc
+
+# Node
+mobile/node_modules/
+mobile/.expo/
+mobile/.expo-shared/
+
+# OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+# Chinese Tutor MVP
+
+A minimal Chinese language tutor with a FastAPI backend and an Expo React Native mobile client.
+
+## Structure
+
+```
+backend/   # FastAPI service
+mobile/    # Expo React Native app (TypeScript)
+```
+
+## Backend (FastAPI)
+
+### Setup
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Run
+
+```bash
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+### Endpoint
+
+`POST /chat`
+
+Request body:
+
+```json
+{
+  "message": "Hi, 我想练习点中文",
+  "level": "beginner"
+}
+```
+
+Response body:
+
+```json
+{
+  "reply": "...",
+  "teaching": {
+    "translation": "...",
+    "pinyin": "...",
+    "key_points": [
+      { "phrase": "你好", "pinyin": "Nǐ hǎo", "meaning": "Hello" }
+    ],
+    "alternatives": ["..."],
+    "follow_up": "..."
+  }
+}
+```
+
+## Mobile (Expo React Native)
+
+### Setup
+
+```bash
+cd mobile
+npm install
+```
+
+### Run
+
+```bash
+npm run start
+```
+
+> If you are testing on a physical device, update the `API_URL` in `mobile/App.tsx` to your machine's LAN IP.
+
+## Notes
+
+- No secrets are committed. Configuration is kept local and minimal.
+- The backend is deterministic for MVP usage and can be swapped with a real LLM later.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="Chinese Tutor API", version="0.1.0")
+
+
+class ChatRequest(BaseModel):
+    message: str = Field(..., min_length=1, description="User input in English, Chinese, or mixed.")
+    level: str = Field("beginner", pattern="^(beginner|intermediate)$")
+
+
+class KeyPoint(BaseModel):
+    phrase: str
+    pinyin: str
+    meaning: str
+
+
+class Teaching(BaseModel):
+    translation: str
+    pinyin: str
+    key_points: list[KeyPoint]
+    alternatives: list[str]
+    follow_up: str
+
+
+class ChatResponse(BaseModel):
+    reply: str
+    teaching: Teaching
+
+
+def _contains_chinese(text: str) -> bool:
+    return any("\u4e00" <= char <= "\u9fff" for char in text)
+
+
+def _simplify_topic(text: str) -> str:
+    words = [word.strip(".,!? ") for word in text.split() if word.strip(".,!? ")]
+    if not words:
+        return "日常生活"
+    return words[0].lower()
+
+
+def _build_beginner_response(message: str) -> ChatResponse:
+    topic = _simplify_topic(message)
+    reply = f"你好！我们可以聊聊{topic}。你今天怎么样？"
+    teaching = Teaching(
+        translation=f"Hi! We can talk about {topic}. How are you today?",
+        pinyin="Nǐ hǎo! Wǒmen kěyǐ liáo liáo " + f"{topic}。 Nǐ jīntiān zěnme yàng?",
+        key_points=[
+            KeyPoint(phrase="你好", pinyin="Nǐ hǎo", meaning="Hello"),
+            KeyPoint(phrase="我们可以", pinyin="Wǒmen kěyǐ", meaning="We can"),
+            KeyPoint(phrase="怎么样", pinyin="Zěnme yàng", meaning="How (is it)"),
+        ],
+        alternatives=["我们聊点别的吧。", "你想聊什么？"],
+        follow_up="用中文回答：你今天感觉如何？",
+    )
+    return ChatResponse(reply=reply, teaching=teaching)
+
+
+def _build_intermediate_response(message: str) -> ChatResponse:
+    topic = _simplify_topic(message)
+    reply = f"明白了。我们可以深入聊聊{topic}，你最感兴趣的部分是什么？"
+    teaching = Teaching(
+        translation=(
+            "Got it. We can talk more in depth about "
+            f"{topic}. Which part interests you most?"
+        ),
+        pinyin=(
+            "Míngbai le. Wǒmen kěyǐ shēnrù liáo liáo "
+            f"{topic}，nǐ zuì gǎn xìngqù de bùfen shì shénme?"
+        ),
+        key_points=[
+            KeyPoint(phrase="明白了", pinyin="Míngbai le", meaning="Got it"),
+            KeyPoint(phrase="深入", pinyin="Shēnrù", meaning="In depth"),
+            KeyPoint(phrase="感兴趣", pinyin="Gǎn xìngqù", meaning="Interested"),
+        ],
+        alternatives=["我们换个话题吧。", "你想先从哪里开始？"],
+        follow_up="试着用中文描述你最感兴趣的一点。",
+    )
+    return ChatResponse(reply=reply, teaching=teaching)
+
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat(request: ChatRequest) -> ChatResponse:
+    message = request.message.strip()
+    if request.level == "intermediate":
+        response = _build_intermediate_response(message)
+    else:
+        response = _build_beginner_response(message)
+
+    if _contains_chinese(message):
+        response.reply = response.reply.replace("我们可以", "我们也可以")
+    return response

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.0
+uvicorn==0.30.6

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,266 @@
+import { useMemo, useState } from "react";
+import {
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+import TeachingCard from "./src/components/TeachingCard";
+import type { ChatMessage, Teaching } from "./src/types/chat";
+
+const API_URL = "http://localhost:8000";
+
+const createId = () => Math.random().toString(36).slice(2, 10);
+
+export default function App() {
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      id: createId(),
+      role: "assistant",
+      text: "你好！我是你的中文导师。我们开始吧！",
+    },
+  ]);
+  const [input, setInput] = useState("");
+  const [level, setLevel] = useState<"beginner" | "intermediate">("beginner");
+  const [isSending, setIsSending] = useState(false);
+
+  const levelLabel = useMemo(
+    () => (level === "beginner" ? "Beginner" : "Intermediate"),
+    [level]
+  );
+
+  const sendMessage = async () => {
+    const trimmed = input.trim();
+    if (!trimmed || isSending) {
+      return;
+    }
+
+    const userMessage: ChatMessage = {
+      id: createId(),
+      role: "user",
+      text: trimmed,
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    setInput("");
+    setIsSending(true);
+
+    try {
+      const response = await fetch(`${API_URL}/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: trimmed, level }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch response");
+      }
+
+      const data = (await response.json()) as { reply: string; teaching: Teaching };
+      const assistantMessage: ChatMessage = {
+        id: createId(),
+        role: "assistant",
+        text: data.reply,
+        teaching: data.teaching,
+      };
+      setMessages((prev) => [...prev, assistantMessage]);
+    } catch (error) {
+      const assistantMessage: ChatMessage = {
+        id: createId(),
+        role: "assistant",
+        text: "抱歉，暂时无法连接到服务器。请稍后再试。",
+      };
+      setMessages((prev) => [...prev, assistantMessage]);
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Chinese Tutor</Text>
+        <View style={styles.levelContainer}>
+          <Text style={styles.levelLabel}>Level</Text>
+          <View style={styles.levelButtons}>
+            {(["beginner", "intermediate"] as const).map((option) => (
+              <TouchableOpacity
+                key={option}
+                style={[
+                  styles.levelButton,
+                  option === level && styles.levelButtonActive,
+                ]}
+                onPress={() => setLevel(option)}
+              >
+                <Text
+                  style={[
+                    styles.levelButtonText,
+                    option === level && styles.levelButtonTextActive,
+                  ]}
+                >
+                  {option === "beginner" ? "Beginner" : "Intermediate"}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+          <Text style={styles.levelHelper}>{levelLabel} mode</Text>
+        </View>
+      </View>
+
+      <ScrollView style={styles.messages} contentContainerStyle={styles.messagesContent}>
+        {messages.map((message) => (
+          <View
+            key={message.id}
+            style={[
+              styles.messageBubble,
+              message.role === "user" ? styles.userBubble : styles.botBubble,
+            ]}
+          >
+            <Text
+              style={
+                message.role === "user" ? styles.userText : styles.botText
+              }
+            >
+              {message.text}
+            </Text>
+            {message.teaching && <TeachingCard teaching={message.teaching} />}
+          </View>
+        ))}
+      </ScrollView>
+
+      <View style={styles.inputBar}>
+        <TextInput
+          style={styles.input}
+          placeholder="Type in English, 中文, or both"
+          value={input}
+          onChangeText={setInput}
+          editable={!isSending}
+        />
+        <TouchableOpacity
+          style={[styles.sendButton, isSending && styles.sendButtonDisabled]}
+          onPress={sendMessage}
+          disabled={isSending}
+        >
+          <Text style={styles.sendButtonText}>{isSending ? "..." : "Send"}</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#FFFFFF",
+  },
+  header: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: "#F0F0F0",
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: "#1F1F1F",
+  },
+  levelContainer: {
+    marginTop: 12,
+  },
+  levelLabel: {
+    fontSize: 12,
+    color: "#6A6A6A",
+    marginBottom: 6,
+  },
+  levelButtons: {
+    flexDirection: "row",
+  },
+  levelButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: "#D0D0D0",
+    marginRight: 8,
+  },
+  levelButtonActive: {
+    backgroundColor: "#2F6FED",
+    borderColor: "#2F6FED",
+  },
+  levelButtonText: {
+    fontSize: 12,
+    color: "#4A4A4A",
+  },
+  levelButtonTextActive: {
+    color: "#FFFFFF",
+  },
+  levelHelper: {
+    marginTop: 6,
+    fontSize: 12,
+    color: "#7A7A7A",
+  },
+  messages: {
+    flex: 1,
+  },
+  messagesContent: {
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+  },
+  messageBubble: {
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 12,
+  },
+  userBubble: {
+    backgroundColor: "#2F6FED",
+    alignSelf: "flex-end",
+  },
+  botBubble: {
+    backgroundColor: "#F6F6F6",
+    alignSelf: "flex-start",
+  },
+  userText: {
+    color: "#FFFFFF",
+    fontSize: 14,
+  },
+  botText: {
+    color: "#1F1F1F",
+    fontSize: 14,
+  },
+  inputBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderTopWidth: 1,
+    borderTopColor: "#F0F0F0",
+  },
+  input: {
+    flex: 1,
+    backgroundColor: "#F7F7F7",
+    borderRadius: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 14,
+  },
+  sendButton: {
+    marginLeft: 10,
+    backgroundColor: "#2F6FED",
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 16,
+  },
+  sendButtonDisabled: {
+    backgroundColor: "#9BB6F5",
+  },
+  sendButtonText: {
+    color: "#FFFFFF",
+    fontWeight: "600",
+    fontSize: 14,
+  },
+});

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,11 @@
+{
+  "expo": {
+    "name": "Chinese Tutor",
+    "slug": "chinese-tutor",
+    "version": "0.1.0",
+    "orientation": "portrait",
+    "sdkVersion": "51.0.0",
+    "platforms": ["ios", "android", "web"],
+    "userInterfaceStyle": "light"
+  }
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+  };
+};

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "chinese-tutor-mobile",
+  "version": "0.1.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~51.0.0",
+    "react": "18.2.0",
+    "react-native": "0.74.5"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.45",
+    "@types/react-native": "0.74.0",
+    "typescript": "5.4.5"
+  }
+}

--- a/mobile/src/components/TeachingCard.tsx
+++ b/mobile/src/components/TeachingCard.tsx
@@ -1,0 +1,66 @@
+import { StyleSheet, Text, View } from "react-native";
+
+import type { Teaching } from "../types/chat";
+
+const TeachingCard = ({ teaching }: { teaching: Teaching }) => {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.heading}>Teaching Notes</Text>
+      <Text style={styles.label}>Translation</Text>
+      <Text style={styles.body}>{teaching.translation}</Text>
+      <Text style={styles.label}>Pinyin</Text>
+      <Text style={styles.body}>{teaching.pinyin}</Text>
+      <Text style={styles.label}>Key Points</Text>
+      {teaching.key_points.map((point) => (
+        <View key={point.phrase} style={styles.keyPoint}>
+          <Text style={styles.body}>• {point.phrase}</Text>
+          <Text style={styles.subtle}>{point.pinyin}</Text>
+          <Text style={styles.subtle}>{point.meaning}</Text>
+        </View>
+      ))}
+      <Text style={styles.label}>Alternatives</Text>
+      {teaching.alternatives.map((alt) => (
+        <Text key={alt} style={styles.body}>
+          • {alt}
+        </Text>
+      ))}
+      <Text style={styles.label}>Follow-up</Text>
+      <Text style={styles.body}>{teaching.follow_up}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: "#F5F7FF",
+    borderRadius: 12,
+    padding: 12,
+    marginTop: 8,
+  },
+  heading: {
+    fontSize: 14,
+    fontWeight: "600",
+    marginBottom: 6,
+    color: "#2F2F2F",
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: "600",
+    marginTop: 6,
+    color: "#4B4B4B",
+  },
+  body: {
+    fontSize: 13,
+    color: "#2F2F2F",
+  },
+  subtle: {
+    fontSize: 12,
+    color: "#6B6B6B",
+    marginLeft: 12,
+  },
+  keyPoint: {
+    marginTop: 4,
+  },
+});
+
+export default TeachingCard;

--- a/mobile/src/types/chat.ts
+++ b/mobile/src/types/chat.ts
@@ -1,0 +1,20 @@
+export type KeyPoint = {
+  phrase: string;
+  pinyin: string;
+  meaning: string;
+};
+
+export type Teaching = {
+  translation: string;
+  pinyin: string;
+  key_points: KeyPoint[];
+  alternatives: string[];
+  follow_up: string;
+};
+
+export type ChatMessage = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  teaching?: Teaching;
+};

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "jsx": "react-native",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["react", "react-native"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, self-contained Chinese tutor MVP with a deterministic backend that returns structured teaching metadata for each chat reply. 
- Support beginner and intermediate levels and mixed English/Chinese input so the app can adapt prompts and teaching content. 
- Deliver a lightweight Expo React Native front end that displays chat messages and inline teaching cards for quick iteration. 
- Keep the project small and safe by avoiding secrets, minimizing dependencies, and documenting setup steps.

### Description
- Add a FastAPI backend in `backend/app/main.py` that defines `ChatRequest`, `ChatResponse`, `Teaching`, and `KeyPoint` models and exposes `POST /chat` which returns `reply` and `teaching` JSON; the handler uses `_contains_chinese` and `_simplify_topic` heuristics and separate `_build_beginner_response` / `_build_intermediate_response` builders. 
- Add `backend/requirements.txt` with pinned `fastapi` and `uvicorn` dependencies and an empty `__init__.py` to make the app package importable. 
- Create an Expo TypeScript mobile client with `mobile/App.tsx` that posts to the `/chat` endpoint, provides beginner/intermediate level controls, queues messages, and renders teaching metadata under assistant messages using a new `TeachingCard` component at `mobile/src/components/TeachingCard.tsx`. 
- Add type definitions in `mobile/src/types/chat.ts`, project configs (`mobile/package.json`, `mobile/tsconfig.json`, `mobile/app.json`, `mobile/babel.config.js`), a project `README.md` with setup/run instructions, and a `.gitignore` to avoid committing env artifacts.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ae486eca883338e4a3d27782707fc)