### PR TITLE
Add onboarding, DeepSeek chat proxy, and streaming-like assistant UI

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.115.0
+httpx==0.27.2
 uvicorn==0.30.6

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chinese-tutor-mobile",
       "version": "0.1.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^1.23.1",
         "expo": "^54.0.31",
         "react": "19.1.0",
         "react-native": "0.81.5"

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,6 +10,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.23.1",
     "expo": "^54.0.31",
     "react": "19.1.0",
     "react-native": "0.81.5"

--- a/mobile/src/types/chat.ts
+++ b/mobile/src/types/chat.ts
@@ -17,4 +17,5 @@ export type ChatMessage = {
   role: "user" | "assistant";
   text: string;
   teaching?: Teaching;
+  isTyping?: boolean;
 };


### PR DESCRIPTION
### Motivation
- Provide a simple onboarding so the app can tailor explanations for English vs Chinese speakers and persist the choice with `AsyncStorage`.
- Move DeepSeek API calls to the server so the API key stays secret and the app can request OpenAI-compatible chat completions via a secure endpoint (`/api/chat`).
- Improve the chat UX so assistant replies render progressively with a typing placeholder and the input bar stays fixed above the keyboard for a smoother MVP experience.

### Description
- Added a FastAPI endpoint `POST /api/chat` that accepts `speaker` and a `messages` array, builds a role-based system prompt via `_build_system_prompt`, proxies the request to DeepSeek using `httpx`, and returns the assistant reply; the server requires `DEEPSEEK_API_KEY` from the environment and returns clear `HTTPException`s on error. 
- Implemented new Pydantic models `DeepSeekMessage`, `DeepSeekChatRequest`, and `DeepSeekChatResponse` and added `httpx==0.27.2` to `backend/requirements.txt`.
- Reworked the Expo app UI (`mobile/App.tsx`) to include an onboarding screen that asks "Are you an English speaker or Chinese speaker?", persists the selection under the `STORAGE_KEY` key in `AsyncStorage`, and uses that preference to set the assistant prompt behavior.
- Updated chat UI: replaced the old ScrollView/level selector with a `FlatList`, a `KeyboardAvoidingView`, a typing placeholder message (`isTyping`), progressive rendering of assistant text via `streamAssistantResponse` (simulated streaming), smooth auto-scroll on new content, and kept the input bar fixed; added `isTyping?: boolean` to `ChatMessage` type and added `@react-native-async-storage/async-storage` to `mobile/package.json`.

### Testing
- No automated tests were added or executed for this change.
- An attempt to install the mobile dependency `@react-native-async-storage/async-storage` in this environment failed with a `403 Forbidden` from the npm registry, so the mobile dependency installation could not be completed here.
- Backend DeepSeek integration performs runtime checks for `DEEPSEEK_API_KEY` and returns `503`/`502` for missing key or upstream errors, respectively, but end-to-end network verification was not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c46c7c01c833389a114f93322c7b4)