### PR TITLE
Refine Gemini prompt structure and output constraints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -110,33 +110,35 @@ def _build_system_prompt(speaker: Literal["english", "chinese"]) -> str:
         "translation, vocabulary, grammar, pronunciation (pinyin), and usage examples. "
         "If the user asks about unrelated topics (politics, health, coding, math, etc.), "
         "politely refuse and redirect them to a language-learning alternative. "
-        "Keep replies concise and tutor-like."
+        "Keep replies concise, conversational, and tutor-like. "
+        "Keep replies to a maximum of 4 lines. "
+        "If more info is needed, ask ONE short follow-up question and wait. "
+        "Always include: Chinese, Pinyin, and a short English explanation. "
+        "Do NOT include character breakdowns. "
+        "Do NOT include multiple examples or long explanations unless the user asks for more detail. "
+        "Provide only one example or tip at a time; do not give multiple examples or tips. "
+        "Split teaching across multiple back-and-forth turns, covering one concept at a time. "
+        "End most responses with a short optional nudge (e.g., “Want an example?”, “Want to practice?”, “Want a casual version?”)."
     )
 
     if speaker == "english":
         return (
             base
             + " Explain in English, include Chinese examples, and provide pinyin for Chinese."
-            + "\n\nAlways respond in this exact structure:\n"
-            + "If the user asks about an unrelated topic:\n"
-            + "- Do NOT answer the topic directly.\n"
-            + "- In the English section, briefly explain you can only help with Chinese ↔ English learning.\n"
-            + "- In the Chinese and Pinyin sections, provide a Chinese translation of the user's question so they can learn how to say it.\n"
-            + "- Still provide an example sentence, quick tip, and follow-up question related to language learning.\n\n"
-            + "Chinese:\n"
-            + "Pinyin:\n"
-            + "English:\n"
-            + "Example sentence (Chinese):\n"
-            + "Example pinyin:\n"
-            + "Example English:\n"
-            + "Quick tip:\n"
-            + "Follow-up question:\n"
         )
 
     return (
         "你是一位中文导师。你的任务仅限于中文↔英文学习：翻译、词汇、语法、发音（拼音）与例句。"
         "如果用户问与语言学习无关的话题（政治、健康、编程、数学等），请礼貌拒绝，并引导回到语言学习任务（例如翻译一句话、解释一个短语）。"
-        "保持简洁、像导师一样。"
+        "保持简洁、对话式、像导师一样。"
+        "每次回复最多4行。"
+        "如果需要更多信息，只问一个简短的追问并等待。"
+        "务必包含：中文、拼音、简短英文解释。"
+        "不要做汉字拆解。"
+        "除非用户要求更多细节，否则不要给多个例子或长解释。"
+        "一次只给一个例子或提示，不要给多个。"
+        "把教学拆成多轮对话，每次只讲一个点。"
+        "大多数回复以简短可选的引导结尾（例如“要例句吗？/要练习吗？/要更口语的版本吗？”）。"
     )
 
 
@@ -162,6 +164,7 @@ async def llm_chat(request: LLMChatRequest) -> LLMChatResponse:
     system_prompt = _build_system_prompt(request.speaker)
     payload = {
         "systemInstruction": {"parts": [{"text": system_prompt}]},
+        "generationConfig": {"maxOutputTokens": 160},
         "contents": [
             {
                 "role": "model" if message.role == "assistant" else "user",


### PR DESCRIPTION
### Motivation
- Ensure assistant replies follow the newly required concise tutor format and include Chinese, pinyin, and a short English explanation. 
- Prevent long multi-example or breakdown-style answers and steer teaching into single, multi-turn steps. 
- Provide a lightweight UX nudge at the end of most replies to encourage the next interaction.

### Description
- Update `backend/app/main.py` `_build_system_prompt` to require concise, conversational tutor replies, a 4-line maximum, one short follow-up question when needed, and mandatory inclusion of Chinese, pinyin, and a short English explanation. 
- Add prohibitions in the system prompt against character breakdowns and multiple examples or long explanations unless explicitly requested. 
- Add guidance to split teaching across multiple turns and to end most responses with a short optional nudge. 
- Ensure the Gemini request payload sets `generationConfig` with `maxOutputTokens: 160` to cap model output length.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697197caf420833383b0e82952973a3e)