### PR TITLE
Unify speech upload to /v1/speech/turn, align mobile client, and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
-### Endpoint
+### Endpoints
 
 `POST /chat`
 
@@ -56,6 +56,17 @@ Response body:
 }
 ```
 
+`POST /v1/speech/turn` (multipart form-data)
+
+```bash
+curl -X POST "http://localhost:8000/v1/speech/turn" \
+  -F "audio=@/path/to/audio.m4a" \
+  -F "level=beginner" \
+  -F "scenario=restaurant" \
+  -F "source_lang=en" \
+  -F "target_lang=zh"
+```
+
 ## Mobile (Expo React Native)
 
 ### Setup
@@ -71,7 +82,8 @@ npm install
 npm run start
 ```
 
-> If you are testing on a physical device, update the `API_URL` in `mobile/App.tsx` to your machine's LAN IP.
+> If you are testing on a physical device, set `EXPO_PUBLIC_API_URL` to your machine's LAN IP
+> (for example, `http://192.168.1.100:8000`).
 
 ## Notes
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -16,7 +16,8 @@ import {
 
 import type { ChatMessage } from "./src/types/chat";
 
-const API_URL = "https://uncircuitous-tuan-legibly.ngrok-free.dev";
+const API_URL =
+  process.env.EXPO_PUBLIC_API_URL ?? "http://192.168.1.100:8000";
 const STORAGE_KEY = "speakerPreference";
 const TYPING_INTERVAL_MS = 18;
 
@@ -296,14 +297,15 @@ export default function App() {
         throw new Error("Missing recording URI");
       }
       const formData = new FormData();
-      formData.append("audio_file", {
+      formData.append("audio", {
         uri,
         name: "speech.m4a",
         type: "audio/mp4",
       } as any);
+      formData.append("level", "beginner");
+      formData.append("scenario", "restaurant");
       formData.append("source_lang", "en");
       formData.append("target_lang", "zh");
-      formData.append("scenario", "restaurant");
 
       const response = await fetch(`${API_URL}/v1/speech/turn`, {
         method: "POST",
@@ -312,9 +314,9 @@ export default function App() {
       });
 
       const raw = await response.text();
+      console.log("Voice Status:", response.status);
+      console.log("Voice Response:", raw);
       if (!response.ok) {
-        console.log("Voice Status: ", response.status);
-        console.log("Voice upload failed:", raw);
         throw new Error(`Voice failed ${response.status}: ${raw}`);
       }
 
@@ -322,6 +324,7 @@ export default function App() {
       setVoiceTurn(data);
       await playVoiceAudio(data.audio);
     } catch (voiceUploadError) {
+      console.error("Voice upload error:", voiceUploadError);
       setVoiceError("Voice request failed. Please try again.");
     } finally {
       setIsUploadingVoice(false);


### PR DESCRIPTION
### Motivation
- Remove duplicated speech endpoints and establish a single canonical route so backend and mobile semantics do not diverge. 
- Provide a mobile-friendly multipart upload shape and fix the bug where `scenario` was mistakenly passed as `level`. 
- Preserve a simple reachability check via `GET /health` and document the final API surface for LAN testing.

### Description
- Implemented a single canonical handler `_speech_turn_handler` and exposed it via `POST /v1/speech/turn` accepting multipart form-data fields `audio`, `level`, `scenario`, `source_lang`, and `target_lang` with sensible defaults. 
- Kept `/speech_turn` as a thin alias that calls the same handler (no duplicated business logic) to avoid breaking clients. 
- Fixed the semantic bug by passing the `scenario` form field through to `service.process()` instead of the previous `level` value. 
- Updated the Expo app (`mobile/App.tsx`) to POST to `/v1/speech/turn` and to send `audio`, `level`, `scenario`, `source_lang`, and `target_lang` as multipart fields, plus improved request/response logging. 
- Updated `README.md` to document `POST /v1/speech/turn`, show `EXPO_PUBLIC_API_URL` usage for LAN testing, and added a `curl` example for local testing.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c457d878483338bf46ae5fad41301)