### PR TITLE
Add chatbot-only mobile mode (EXPO_PUBLIC_CHATBOT_ONLY_MODE) and EAS APK build profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ For demo-only flows, you can temporarily set `DEMO_DISABLE_AUTH=true` on the bac
 `EXPO_PUBLIC_DEMO_MODE=true` on the mobile app to bypass lock/login screens and open
 directly to the chatbot UI.
 
+If you only want the chatbot screen in mobile (no lock, no login, no onboarding),
+set `EXPO_PUBLIC_CHATBOT_ONLY_MODE=true`. This auto-selects the English speaker path.
+
 ### Endpoints
 
 `POST /auth/login`
@@ -141,6 +144,24 @@ npm run start
 
 > Set `EXPO_PUBLIC_API_URL` to your deployed HTTPS API (no localhost/LAN).
 > Set `EXPO_PUBLIC_DEMO_MODE=true` only when you need a login-free demo build.
+> Set `EXPO_PUBLIC_CHATBOT_ONLY_MODE=true` when you want chatbot-only UI.
+
+### Build an Android file (.apk) to share
+
+If your partner wants an installable Android file, create an APK with EAS:
+
+```bash
+cd mobile
+npm install
+npx eas-cli login
+EXPO_PUBLIC_API_URL=https://api.example.com \
+EXPO_PUBLIC_CHATBOT_ONLY_MODE=true \
+npx eas build --platform android --profile preview
+```
+
+- Download the generated `.apk` from the EAS build link and share it directly.
+- `preview` profile in `mobile/eas.json` is configured for `apk` output.
+- For Play Store uploads later, use `--profile production` (AAB output).
 
 ## Notes
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -35,6 +35,9 @@ const isTruthy = (value: string | undefined) =>
   ["1", "true", "yes", "on"].includes((value ?? "").toLowerCase());
 
 const DEMO_MODE = isTruthy(process.env.EXPO_PUBLIC_DEMO_MODE);
+const CHATBOT_ONLY_MODE = isTruthy(
+  process.env.EXPO_PUBLIC_CHATBOT_ONLY_MODE
+);
 
 const createId = () => Math.random().toString(36).slice(2, 10);
 
@@ -130,7 +133,7 @@ export default function App() {
   useEffect(() => {
     logApiBaseUrl("App start");
     const loadAppLock = async () => {
-      if (DEMO_MODE) {
+      if (DEMO_MODE || CHATBOT_ONLY_MODE) {
         setIsAppUnlocked(true);
         setIsLoadingAppLock(false);
         return;
@@ -155,7 +158,7 @@ export default function App() {
         return;
       }
       setApiError(null);
-      if (DEMO_MODE) {
+      if (DEMO_MODE || CHATBOT_ONLY_MODE) {
         setIsAuthenticated(true);
         setIsBootstrapping(false);
         return;
@@ -200,8 +203,15 @@ export default function App() {
     loadPreference();
   }, [isAppUnlocked, isAuthenticated]);
 
+  useEffect(() => {
+    if (!CHATBOT_ONLY_MODE || preference) {
+      return;
+    }
+    setPreference("english");
+  }, [preference, CHATBOT_ONLY_MODE]);
+
   const handleUnlock = async () => {
-    if (DEMO_MODE) {
+    if (DEMO_MODE || CHATBOT_ONLY_MODE) {
       setIsAppUnlocked(true);
       return;
     }
@@ -215,7 +225,7 @@ export default function App() {
   };
 
   const handleLock = async () => {
-    if (DEMO_MODE) {
+    if (DEMO_MODE || CHATBOT_ONLY_MODE) {
       return;
     }
     await clearUnlock();
@@ -668,7 +678,7 @@ export default function App() {
     );
   }
 
-  if (!DEMO_MODE && !isAuthenticated) {
+  if (!DEMO_MODE && !CHATBOT_ONLY_MODE && !isAuthenticated) {
     return (
       <AuthScreen
         onSubmit={handleLogin}
@@ -698,12 +708,15 @@ export default function App() {
         keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 24}
       >
         <View style={styles.header}>
-          <Text style={styles.title} onLongPress={handleLock}>
+          <Text
+            style={styles.title}
+            onLongPress={DEMO_MODE || CHATBOT_ONLY_MODE ? undefined : handleLock}
+          >
             Chinese Tutor
           </Text>
           <View style={styles.headerRow}>
             <Text style={styles.subtitle}>{systemHint}</Text>
-            {DEMO_MODE ? null : (
+            {DEMO_MODE || CHATBOT_ONLY_MODE ? null : (
               <TouchableOpacity onPress={handleLogout}>
                 <Text style={styles.logoutText}>Logout</Text>
               </TouchableOpacity>

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -1,0 +1,18 @@
+{
+  "cli": {
+    "version": ">= 16.0.0"
+  },
+  "build": {
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight chatbot-only mode for mobile builds to bypass lock/login/onboarding for demos or partner APKs.
- Make it easy to produce an installable Android `.apk` for distribution via EAS preview builds.

### Description
- Add `EXPO_PUBLIC_CHATBOT_ONLY_MODE` to the README and document usage and build steps including the `npx eas build` example and notes about `preview` vs `production` profiles.
- Implement `CHATBOT_ONLY_MODE` in `mobile/App.tsx` by parsing `process.env.EXPO_PUBLIC_CHATBOT_ONLY_MODE` and treating it like `DEMO_MODE` for unlocking, authentication bootstrap, and hiding logout/lock UI, and auto-selecting the English speaker preference when unset.
- Disable the long-press lock action when `CHATBOT_ONLY_MODE` or `DEMO_MODE` is active to prevent locking the app, and ensure onboarding/login flows are skipped appropriately.
- Add `mobile/eas.json` with a `preview` profile configured to output an `apk` and a `production` profile for app-bundle uploads.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c316ffa9a083339de854d33fb6a741)