### PR TITLE
Support chatbot-only and optional-auth mobile modes; add EAS APK build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ For demo-only flows, you can temporarily set `DEMO_DISABLE_AUTH=true` on the bac
 `EXPO_PUBLIC_DEMO_MODE=true` on the mobile app to bypass lock/login screens and open
 directly to the chatbot UI.
 
+If you only want the chatbot screen in mobile (no lock, no login, no onboarding),
+set `EXPO_PUBLIC_CHATBOT_ONLY_MODE=true`. This auto-selects the English speaker path.
+
 ### Endpoints
 
 `POST /auth/login`
@@ -141,6 +144,26 @@ npm run start
 
 > Set `EXPO_PUBLIC_API_URL` to your deployed HTTPS API (no localhost/LAN).
 > Set `EXPO_PUBLIC_DEMO_MODE=true` only when you need a login-free demo build.
+> Set `EXPO_PUBLIC_CHATBOT_ONLY_MODE=true` when you want chatbot-only UI.
+> Sign-in is now optional by default. Set `EXPO_PUBLIC_REQUIRE_AUTH=true` only if you want the login screen enabled in production builds.
+> When `EXPO_PUBLIC_REQUIRE_AUTH` is not `true`, the mobile client will not call `/auth/refresh` on `401` responses.
+
+### Build an Android file (.apk) to share
+
+If your partner wants an installable Android file, create an APK with EAS:
+
+```bash
+cd mobile
+npm install
+npx eas-cli login
+EXPO_PUBLIC_API_URL=https://api.example.com \
+EXPO_PUBLIC_CHATBOT_ONLY_MODE=true \
+npx eas build --platform android --profile preview
+```
+
+- Download the generated `.apk` from the EAS build link and share it directly.
+- `preview` profile in `mobile/eas.json` is configured for `apk` output.
+- For Play Store uploads later, use `--profile production` (AAB output).
 
 ## Notes
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -35,6 +35,12 @@ const isTruthy = (value: string | undefined) =>
   ["1", "true", "yes", "on"].includes((value ?? "").toLowerCase());
 
 const DEMO_MODE = isTruthy(process.env.EXPO_PUBLIC_DEMO_MODE);
+const CHATBOT_ONLY_MODE = isTruthy(
+  process.env.EXPO_PUBLIC_CHATBOT_ONLY_MODE
+);
+const REQUIRE_AUTH =
+  isTruthy(process.env.EXPO_PUBLIC_REQUIRE_AUTH) &&
+  process.env.NODE_ENV === "production";
 
 const createId = () => Math.random().toString(36).slice(2, 10);
 
@@ -130,7 +136,7 @@ export default function App() {
   useEffect(() => {
     logApiBaseUrl("App start");
     const loadAppLock = async () => {
-      if (DEMO_MODE) {
+      if (DEMO_MODE || CHATBOT_ONLY_MODE) {
         setIsAppUnlocked(true);
         setIsLoadingAppLock(false);
         return;
@@ -155,7 +161,7 @@ export default function App() {
         return;
       }
       setApiError(null);
-      if (DEMO_MODE) {
+      if (DEMO_MODE || CHATBOT_ONLY_MODE || !REQUIRE_AUTH) {
         setIsAuthenticated(true);
         setIsBootstrapping(false);
         return;
@@ -200,8 +206,15 @@ export default function App() {
     loadPreference();
   }, [isAppUnlocked, isAuthenticated]);
 
+  useEffect(() => {
+    if (!CHATBOT_ONLY_MODE || preference) {
+      return;
+    }
+    setPreference("english");
+  }, [preference, CHATBOT_ONLY_MODE]);
+
   const handleUnlock = async () => {
-    if (DEMO_MODE) {
+    if (DEMO_MODE || CHATBOT_ONLY_MODE) {
       setIsAppUnlocked(true);
       return;
     }
@@ -215,7 +228,7 @@ export default function App() {
   };
 
   const handleLock = async () => {
-    if (DEMO_MODE) {
+    if (DEMO_MODE || CHATBOT_ONLY_MODE) {
       return;
     }
     await clearUnlock();
@@ -668,7 +681,12 @@ export default function App() {
     );
   }
 
-  if (!DEMO_MODE && !isAuthenticated) {
+  if (
+    REQUIRE_AUTH &&
+    !DEMO_MODE &&
+    !CHATBOT_ONLY_MODE &&
+    !isAuthenticated
+  ) {
     return (
       <AuthScreen
         onSubmit={handleLogin}
@@ -698,12 +716,15 @@ export default function App() {
         keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 24}
       >
         <View style={styles.header}>
-          <Text style={styles.title} onLongPress={handleLock}>
+          <Text
+            style={styles.title}
+            onLongPress={DEMO_MODE || CHATBOT_ONLY_MODE ? undefined : handleLock}
+          >
             Chinese Tutor
           </Text>
           <View style={styles.headerRow}>
             <Text style={styles.subtitle}>{systemHint}</Text>
-            {DEMO_MODE ? null : (
+            {DEMO_MODE || CHATBOT_ONLY_MODE || !REQUIRE_AUTH ? null : (
               <TouchableOpacity onPress={handleLogout}>
                 <Text style={styles.logoutText}>Logout</Text>
               </TouchableOpacity>

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -1,0 +1,18 @@
+{
+  "cli": {
+    "version": ">= 16.0.0"
+  },
+  "build": {
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  }
+}

--- a/mobile/src/config/apiClient.ts
+++ b/mobile/src/config/apiClient.ts
@@ -1,7 +1,7 @@
 import { Platform } from "react-native";
 
 import { API_BASE_URL } from "./api";
-import { getAccessToken, refreshSession } from "./auth";
+import { AUTH_REQUIRED, getAccessToken, refreshSession } from "./auth";
 
 const CLIENT_TYPE = Platform.OS === "web" ? "web" : "mobile";
 
@@ -28,7 +28,7 @@ export const apiFetch = async (
     credentials: withCredentials,
   });
 
-  if (response.status === 401 && retry) {
+  if (AUTH_REQUIRED && response.status === 401 && retry) {
     const refreshed = await refreshSession();
     if (refreshed) {
       return apiFetch(path, options, false);

--- a/mobile/src/config/auth.ts
+++ b/mobile/src/config/auth.ts
@@ -3,6 +3,13 @@ import { Platform } from "react-native";
 
 import { API_BASE_URL } from "./api";
 
+const isTruthy = (value: string | undefined) =>
+  ["1", "true", "yes", "on"].includes((value ?? "").toLowerCase());
+
+export const AUTH_REQUIRED =
+  isTruthy(process.env.EXPO_PUBLIC_REQUIRE_AUTH) &&
+  process.env.NODE_ENV === "production";
+
 const REFRESH_TOKEN_KEY = "refreshToken";
 const CLIENT_TYPE = Platform.OS === "web" ? "web" : "mobile";
 


### PR DESCRIPTION
### Motivation
- Allow the mobile client to run a chatbot-only experience without lock/login screens via a new environment flag and make sign-in optional for production builds. 
- Prevent unnecessary refresh attempts and login flows when authentication is intentionally disabled on the client. 
- Provide an easy way to produce a sharable Android APK via Expo Application Services (EAS).

### Description
- Add `EXPO_PUBLIC_CHATBOT_ONLY_MODE` and `EXPO_PUBLIC_REQUIRE_AUTH` handling to the mobile app and default the speaker to English when chatbot-only mode is enabled by setting preference in `App.tsx`. 
- Make unlock/lock and logout behavior conditional so long-press locking and logout are disabled in demo/chatbot-only/optional-auth scenarios in `App.tsx`. 
- Expose `AUTH_REQUIRED` in `mobile/src/config/auth.ts` and gate token refresh logic in `mobile/src/config/apiClient.ts` so the client will not attempt refresh on `401` when auth is not required. 
- Add `mobile/eas.json` to configure EAS `preview` (`apk`) and `production` (`app-bundle`) Android builds and update `README.md` with new environment variables and EAS APK build instructions. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c316ffa9a083339de854d33fb6a741)