### PR TITLE
Add animated theme system, ambient background blobs, and header/voice UI polish

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -55,6 +55,18 @@ const wait = (ms: number) =>
 type SpeakerPreference = "english" | "chinese";
 type MicPermissionState = "undetermined" | "granted" | "denied";
 type VoiceOption = "warm" | "bright" | "deep";
+type ModeTheme = {
+  gradientTop: string;
+  gradientBottom: string;
+  blobPrimary: string;
+  blobSecondary: string;
+  headerSurface: string;
+  headerGlow: string;
+  headerAccentTrack: string;
+  headerAccentLine: string;
+  surfaceTint: string;
+  surfaceBorder: string;
+};
 
 type SpeechTurnAudio = {
   format: "mp3" | "wav";
@@ -213,6 +225,45 @@ const useMicroButton = () => {
   };
 };
 
+const MODE_THEMES: Record<VoiceOption, ModeTheme> = {
+  warm: {
+    gradientTop: "#FFF8EE",
+    gradientBottom: "#FFEFE3",
+    blobPrimary: "rgba(251, 146, 120, 0.24)",
+    blobSecondary: "rgba(253, 186, 116, 0.2)",
+    headerSurface: "rgba(255, 249, 239, 0.68)",
+    headerGlow: "rgba(251, 191, 36, 0.12)",
+    headerAccentTrack: "rgba(194, 65, 12, 0.1)",
+    headerAccentLine: "rgba(234, 88, 12, 0.45)",
+    surfaceTint: "#FFEDD5",
+    surfaceBorder: "#FDBA74",
+  },
+  bright: {
+    gradientTop: "#F7FCFF",
+    gradientBottom: "#EAF6FF",
+    blobPrimary: "rgba(125, 211, 252, 0.2)",
+    blobSecondary: "rgba(103, 232, 249, 0.18)",
+    headerSurface: "rgba(245, 252, 255, 0.7)",
+    headerGlow: "rgba(56, 189, 248, 0.14)",
+    headerAccentTrack: "rgba(14, 165, 233, 0.12)",
+    headerAccentLine: "rgba(2, 132, 199, 0.42)",
+    surfaceTint: "#ECFEFF",
+    surfaceBorder: "#A5F3FC",
+  },
+  deep: {
+    gradientTop: "#F5F0FF",
+    gradientBottom: "#E7E2F4",
+    blobPrimary: "rgba(109, 40, 217, 0.18)",
+    blobSecondary: "rgba(49, 46, 129, 0.18)",
+    headerSurface: "rgba(243, 239, 252, 0.72)",
+    headerGlow: "rgba(99, 102, 241, 0.14)",
+    headerAccentTrack: "rgba(79, 70, 229, 0.12)",
+    headerAccentLine: "rgba(67, 56, 202, 0.44)",
+    surfaceTint: "#EFE7FF",
+    surfaceBorder: "#C4B5FD",
+  },
+};
+
 
 const Onboarding = ({
   onSelect,
@@ -284,6 +335,12 @@ export default function App() {
   const inputFocusAnim = useRef(new Animated.Value(0)).current;
   const sendBurstAnim = useRef(new Animated.Value(0)).current;
   const stageTransition = useRef(new Animated.Value(0)).current;
+  const ambientDriftA = useRef(new Animated.Value(0)).current;
+  const ambientDriftB = useRef(new Animated.Value(0)).current;
+  const headerEntrance = useRef(new Animated.Value(0)).current;
+  const themeProgress = useRef(new Animated.Value(1)).current;
+  const [themeFrom, setThemeFrom] = useState<VoiceOption>(selectedVoice);
+  const [themeTo, setThemeTo] = useState<VoiceOption>(selectedVoice);
 
   useEffect(() => {
     logApiBaseUrl("App start");
@@ -442,6 +499,29 @@ export default function App() {
     }
     return "";
   }, [preference]);
+
+  const interpolatedTheme = useMemo(() => {
+    const fromTheme = MODE_THEMES[themeFrom];
+    const toTheme = MODE_THEMES[themeTo];
+    const interpolateColor = (key: keyof ModeTheme) =>
+      themeProgress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [fromTheme[key], toTheme[key]],
+      });
+
+    return {
+      gradientTop: interpolateColor("gradientTop"),
+      gradientBottom: interpolateColor("gradientBottom"),
+      blobPrimary: interpolateColor("blobPrimary"),
+      blobSecondary: interpolateColor("blobSecondary"),
+      headerSurface: interpolateColor("headerSurface"),
+      headerGlow: interpolateColor("headerGlow"),
+      headerAccentTrack: interpolateColor("headerAccentTrack"),
+      headerAccentLine: interpolateColor("headerAccentLine"),
+      surfaceTint: interpolateColor("surfaceTint"),
+      surfaceBorder: interpolateColor("surfaceBorder"),
+    };
+  }, [themeFrom, themeProgress, themeTo]);
 
   useEffect(() => {
     if (!preference || messages.length > 0) {
@@ -831,6 +911,77 @@ export default function App() {
     }).start();
   }, [stageTransition, voiceStageState]);
 
+  useEffect(() => {
+    ambientDriftA.setValue(0);
+    ambientDriftB.setValue(0);
+
+    const loopA = Animated.loop(
+      Animated.sequence([
+        Animated.timing(ambientDriftA, {
+          toValue: 1,
+          duration: 30000,
+          easing: Easing.inOut(Easing.sin),
+          useNativeDriver: true,
+        }),
+        Animated.timing(ambientDriftA, {
+          toValue: 0,
+          duration: 30000,
+          easing: Easing.inOut(Easing.sin),
+          useNativeDriver: true,
+        }),
+      ])
+    );
+
+    const loopB = Animated.loop(
+      Animated.sequence([
+        Animated.timing(ambientDriftB, {
+          toValue: 1,
+          duration: 42000,
+          easing: Easing.inOut(Easing.sin),
+          useNativeDriver: true,
+        }),
+        Animated.timing(ambientDriftB, {
+          toValue: 0,
+          duration: 42000,
+          easing: Easing.inOut(Easing.sin),
+          useNativeDriver: true,
+        }),
+      ])
+    );
+
+    loopA.start();
+    loopB.start();
+
+    return () => {
+      loopA.stop();
+      loopB.stop();
+    };
+  }, [ambientDriftA, ambientDriftB]);
+
+  useEffect(() => {
+    if (selectedVoice === themeTo) {
+      return;
+    }
+    setThemeFrom(themeTo);
+    setThemeTo(selectedVoice);
+    themeProgress.setValue(0);
+    Animated.timing(themeProgress, {
+      toValue: 1,
+      duration: 900,
+      easing: Easing.inOut(Easing.cubic),
+      useNativeDriver: false,
+    }).start();
+  }, [selectedVoice, themeProgress, themeTo]);
+
+  useEffect(() => {
+    Animated.timing(headerEntrance, {
+      toValue: 1,
+      duration: 680,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [headerEntrance]);
+
   const handleMicPress = async () => {
     if (isUploadingVoice) {
       return;
@@ -911,27 +1062,135 @@ export default function App() {
 
   return (
     <SafeAreaView style={styles.container}>
+      <View pointerEvents="none" style={styles.ambientBackground}>
+        <Animated.View
+          style={[
+            styles.ambientGradientLayer,
+            { backgroundColor: interpolatedTheme.gradientTop },
+          ]}
+        />
+        <Animated.View
+          style={[
+            styles.ambientGradientLayerBottom,
+            { backgroundColor: interpolatedTheme.gradientBottom },
+          ]}
+        />
+        <Animated.View
+          style={[
+            styles.ambientBlobPrimary,
+            {
+              backgroundColor: interpolatedTheme.blobPrimary,
+              transform: [
+                {
+                  translateX: ambientDriftA.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [-24, 26],
+                  }),
+                },
+                {
+                  translateY: ambientDriftA.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [-18, 22],
+                  }),
+                },
+                {
+                  scale: ambientDriftA.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [1, 1.08],
+                  }),
+                },
+              ],
+            },
+          ]}
+        />
+        <Animated.View
+          style={[
+            styles.ambientBlobSecondary,
+            {
+              backgroundColor: interpolatedTheme.blobSecondary,
+              transform: [
+                {
+                  translateX: ambientDriftB.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [22, -26],
+                  }),
+                },
+                {
+                  translateY: ambientDriftB.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [20, -18],
+                  }),
+                },
+                {
+                  scale: ambientDriftB.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [1.03, 0.98],
+                  }),
+                },
+              ],
+            },
+          ]}
+        />
+      </View>
       <KeyboardAvoidingView
         style={styles.keyboardAvoid}
         behavior={Platform.OS === "ios" ? "padding" : "height"}
         keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 24}
       >
-        <View style={styles.header}>
-          <Text
-            style={styles.title}
-            onLongPress={DEMO_MODE || CHATBOT_ONLY_MODE ? undefined : handleLock}
-          >
-            Chinese Tutor
-          </Text>
-          <View style={styles.headerRow}>
-            <Text style={styles.subtitle}>{systemHint}</Text>
+        <Animated.View
+          style={[
+            styles.headerHero,
+            {
+              backgroundColor: interpolatedTheme.headerSurface,
+              opacity: headerEntrance.interpolate({
+                inputRange: [0, 1],
+                outputRange: [0, 1],
+              }),
+              transform: [
+                {
+                  translateY: headerEntrance.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [10, 0],
+                  }),
+                },
+              ],
+            },
+          ]}
+        >
+          <Animated.View
+            style={[
+              styles.headerAccentGlow,
+              { backgroundColor: interpolatedTheme.headerGlow },
+            ]}
+          />
+          <View style={styles.headerTitleRow}>
+            <Text
+              style={styles.title}
+              onLongPress={DEMO_MODE || CHATBOT_ONLY_MODE ? undefined : handleLock}
+            >
+              Chinese Tutor
+            </Text>
             {DEMO_MODE || CHATBOT_ONLY_MODE || !REQUIRE_AUTH ? null : (
               <Pressable onPress={handleLogout}>
                 <Text style={styles.logoutText}>Logout</Text>
               </Pressable>
             )}
           </View>
-        </View>
+          <Text style={styles.subtitle}>{systemHint}</Text>
+          <Animated.View
+            style={[
+              styles.headerAccentTrack,
+              { backgroundColor: interpolatedTheme.headerAccentTrack },
+            ]}
+          >
+            <Animated.View
+              style={[
+                styles.headerAccentLine,
+                { backgroundColor: interpolatedTheme.headerAccentLine },
+              ]}
+            />
+          </Animated.View>
+        </Animated.View>
 
         {error ? (
           <View style={styles.errorBanner}>
@@ -939,7 +1198,15 @@ export default function App() {
           </View>
         ) : null}
 
-        <View style={styles.voiceCard}>
+        <Animated.View
+          style={[
+            styles.voiceCard,
+            {
+              backgroundColor: interpolatedTheme.surfaceTint,
+              borderColor: interpolatedTheme.surfaceBorder,
+            },
+          ]}
+        >
           <Text style={styles.voiceTitle}>Voice Turn</Text>
           <Text style={styles.voiceSubtitle}>
             Hold the button, speak, and release to translate + hear it back.
@@ -1020,7 +1287,7 @@ export default function App() {
               ) : null}
             </View>
           ) : null}
-        </View>
+        </Animated.View>
 
         <FlatList
           ref={listRef}
@@ -1131,7 +1398,40 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#FFF7ED",
+    backgroundColor: "#FDF8F2",
+  },
+  ambientBackground: {
+    ...StyleSheet.absoluteFillObject,
+    overflow: "hidden",
+  },
+  ambientGradientLayer: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  ambientGradientLayerBottom: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: "68%",
+    opacity: 0.82,
+  },
+  ambientBlobPrimary: {
+    position: "absolute",
+    width: 420,
+    height: 420,
+    borderRadius: 420,
+    top: -120,
+    right: -120,
+    opacity: 0.75,
+  },
+  ambientBlobSecondary: {
+    position: "absolute",
+    width: 460,
+    height: 460,
+    borderRadius: 460,
+    bottom: -170,
+    left: -150,
+    opacity: 0.62,
   },
   keyboardAvoid: {
     flex: 1,
@@ -1141,28 +1441,50 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
   },
-  header: {
+  headerHero: {
     paddingHorizontal: 20,
-    paddingTop: 16,
-    paddingBottom: 8,
+    paddingTop: 18,
+    paddingBottom: 14,
     borderBottomWidth: 1,
-    borderBottomColor: "#F5D0A9",
+    borderBottomColor: "rgba(245, 208, 169, 0.55)",
   },
-  title: {
-    fontSize: 22,
-    fontWeight: "700",
-    color: "#7C2D12",
-  },
-  subtitle: {
-    marginTop: 6,
-    fontSize: 12,
-    color: "#B45309",
-  },
-  headerRow: {
-    marginTop: 6,
+  headerTitleRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
+  },
+  headerAccentGlow: {
+    position: "absolute",
+    width: 190,
+    height: 190,
+    borderRadius: 190,
+    right: -70,
+    top: -90,
+  },
+  title: {
+    fontSize: 30,
+    lineHeight: 34,
+    fontWeight: "800",
+    letterSpacing: -0.4,
+    color: "#6B2C12",
+  },
+  subtitle: {
+    marginTop: 8,
+    fontSize: 13,
+    lineHeight: 18,
+    color: "#9A5A2B",
+  },
+  headerAccentTrack: {
+    marginTop: 10,
+    width: "100%",
+    height: 2,
+    borderRadius: 2,
+    overflow: "hidden",
+  },
+  headerAccentLine: {
+    width: "42%",
+    height: "100%",
+    borderRadius: 2,
   },
   logoutText: {
     fontSize: 12,
@@ -1302,9 +1624,7 @@ const styles = StyleSheet.create({
     marginTop: 12,
     padding: 16,
     borderRadius: 16,
-    backgroundColor: "#FFEDD5",
     borderWidth: 1,
-    borderColor: "#FDBA74",
   },
   voiceTitle: {
     fontSize: 16,


### PR DESCRIPTION
### Motivation
- Introduce a dynamic, polished visual system so the app shifts appearance with the selected voice mode and feels more engaging.
- Provide subtle ambient motion and an animated header to give visual context to voice/theme changes.
- Replace static color tokens with interpolated themes so transitions between `warm`, `bright`, and `deep` modes animate smoothly.

### Description
- Added a `ModeTheme` type and `MODE_THEMES` mapping for `warm`, `bright`, and `deep` voice modes, and created `interpolatedTheme` to interpolate theme colors via `themeProgress`.
- Introduced animated state (`ambientDriftA`, `ambientDriftB`, `headerEntrance`, `themeProgress`) and effects to drive ambient gradient layers, two drifting blobs, and a header entrance animation in `mobile/App.tsx`.
- Reworked the header into an animated `headerHero` with glow and accent track, converted the voice card into an animated surface that applies `interpolatedTheme.surfaceTint` and `interpolatedTheme.surfaceBorder`, and wired theme transitions to `selectedVoice` changes.
- Updated `styles` and layout (background, ambient layers, blobs, header, voice card and typography) to support the new animated visuals and refined spacing/typography.

### Testing
- Ran TypeScript type check with `tsc --noEmit` and it completed successfully.
- Ran linter via `npm run lint` and no new lint errors were reported.
- Executed the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c33a817b50833391524a0482698010)