### PR TITLE
Add StructuredLearningCard for assistant messages and refine chat/voice styles

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -20,6 +20,9 @@ import {
 import ApiBlockedScreen from "./src/components/ApiBlockedScreen";
 import AuthScreen from "./src/components/AuthScreen";
 import LockScreen from "./src/components/LockScreen";
+import StructuredLearningCard, {
+  parseLearningCard,
+} from "./src/components/StructuredLearningCard";
 import VoiceStage, { type VoiceStageState } from "./src/components/VoiceStage";
 import {
   clearUnlock,
@@ -178,6 +181,8 @@ const MessageBubble = ({ item }: { item: ChatMessage }) => {
     >
       {item.isTyping ? (
         <TypingIndicator />
+      ) : item.role === "assistant" ? (
+        <StructuredLearningCard {...parseLearningCard(item.text)} />
       ) : (
         <Text style={item.role === "user" ? styles.userText : styles.botText}>
           {item.text}
@@ -1514,14 +1519,14 @@ const styles = StyleSheet.create({
     elevation: 1,
   },
   botBubble: {
-    backgroundColor: "#FFF5FF",
-    borderColor: "#E9D5FF",
+    backgroundColor: "transparent",
+    borderColor: "transparent",
     alignSelf: "flex-start",
-    shadowColor: "#A855F7",
-    shadowOpacity: 0.16,
-    shadowRadius: 10,
-    shadowOffset: { width: 0, height: 3 },
-    elevation: 2,
+    paddingHorizontal: 0,
+    paddingVertical: 0,
+    borderWidth: 0,
+    shadowOpacity: 0,
+    elevation: 0,
   },
   userText: {
     color: "#7C2D12",

--- a/mobile/src/components/StructuredLearningCard.tsx
+++ b/mobile/src/components/StructuredLearningCard.tsx
@@ -1,0 +1,164 @@
+import { Animated, StyleSheet, Text, View } from "react-native";
+import { useEffect, useMemo, useRef } from "react";
+
+type StructuredLearningCardProps = {
+  chinese: string;
+  pinyin?: string;
+  english: string;
+  tip?: string;
+};
+
+const HAN_REGEX = /[\u3400-\u9FFF]/;
+
+const sanitize = (value?: string) => value?.trim() ?? "";
+
+export const parseLearningCard = (text: string) => {
+  const normalized = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const taggedChinese = normalized.find((line) => /^chinese\s*:/i.test(line));
+  const taggedPinyin = normalized.find((line) => /^pinyin\s*:/i.test(line));
+  const taggedEnglish = normalized.find(
+    (line) => /^(english|meaning|translation)\s*:/i.test(line)
+  );
+  const taggedTip = normalized.find((line) => /^tip\s*:/i.test(line));
+
+  const chineseFromTag = taggedChinese?.replace(/^chinese\s*:/i, "").trim();
+  const pinyinFromTag = taggedPinyin?.replace(/^pinyin\s*:/i, "").trim();
+  const englishFromTag = taggedEnglish
+    ?.replace(/^(english|meaning|translation)\s*:/i, "")
+    .trim();
+  const tipFromTag = taggedTip?.replace(/^tip\s*:/i, "").trim();
+
+  const chineseFallback =
+    normalized.find((line) => HAN_REGEX.test(line) && line.length <= 40) ?? "";
+
+  const pinyinFallback = normalized.find(
+    (line) =>
+      !HAN_REGEX.test(line) &&
+      /[āáǎàēéěèīíǐìōóǒòūúǔùǖǘǚǜ]/i.test(line)
+  );
+
+  const englishFallback = normalized.find(
+    (line) => !HAN_REGEX.test(line) && line !== pinyinFallback
+  );
+
+  return {
+    chinese: sanitize(chineseFromTag) || sanitize(chineseFallback) || "学习短句",
+    pinyin: sanitize(pinyinFromTag) || sanitize(pinyinFallback),
+    english:
+      sanitize(englishFromTag) ||
+      sanitize(englishFallback) ||
+      sanitize(text) ||
+      "Let's learn this phrase.",
+    tip: sanitize(tipFromTag),
+  };
+};
+
+const StructuredLearningCard = ({
+  chinese,
+  pinyin,
+  english,
+  tip,
+}: StructuredLearningCardProps) => {
+  const entrance = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(entrance, {
+      toValue: 1,
+      duration: 360,
+      useNativeDriver: true,
+    }).start();
+  }, [entrance]);
+
+  const cardStyle = useMemo(
+    () => ({
+      opacity: entrance,
+      transform: [
+        {
+          translateY: entrance.interpolate({
+            inputRange: [0, 1],
+            outputRange: [12, 0],
+          }),
+        },
+      ],
+    }),
+    [entrance]
+  );
+
+  return (
+    <Animated.View style={[styles.card, cardStyle]}>
+      <Text style={styles.chinese}>{chinese}</Text>
+      {pinyin ? <Text style={styles.pinyin}>{pinyin}</Text> : null}
+      <Text style={styles.english}>{english}</Text>
+
+      {tip ? (
+        <View style={styles.tipBox}>
+          <Text style={styles.tipTitle}>💡 Tip</Text>
+          <Text style={styles.tipText}>{tip}</Text>
+        </View>
+      ) : null}
+
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 18,
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+    backgroundColor: "rgba(255, 255, 255, 0.92)",
+    borderWidth: 1,
+    borderColor: "rgba(232, 213, 255, 0.95)",
+    shadowColor: "#7E22CE",
+    shadowOpacity: 0.14,
+    shadowOffset: { width: 0, height: 8 },
+    shadowRadius: 16,
+    elevation: 3,
+    gap: 8,
+  },
+  chinese: {
+    fontSize: 30,
+    lineHeight: 38,
+    fontWeight: "700",
+    color: "#3B0764",
+    textAlign: "center",
+  },
+  pinyin: {
+    fontSize: 15,
+    lineHeight: 20,
+    textAlign: "center",
+    color: "#7E22CE",
+  },
+  english: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: "#6B7280",
+    textAlign: "center",
+  },
+  tipBox: {
+    marginTop: 4,
+    backgroundColor: "#FAF5FF",
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderColor: "#E9D5FF",
+  },
+  tipTitle: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: "#6B21A8",
+    marginBottom: 4,
+  },
+  tipText: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: "#6D28D9",
+  },
+});
+
+export default StructuredLearningCard;

--- a/mobile/src/components/VoiceStage.tsx
+++ b/mobile/src/components/VoiceStage.tsx
@@ -432,6 +432,7 @@ const VoiceStage = ({
       <Animated.Text
         style={[
           styles.statusText,
+          state === "idle" ? styles.statusTextIdle : null,
           {
             opacity: stateMorph.interpolate({
               inputRange: [0, 1, 2, 3],
@@ -544,9 +545,13 @@ const styles = StyleSheet.create({
   statusText: {
     marginTop: 14,
     fontSize: 13,
-    color: "#CDE5FF",
+    color: "#6B7280",
     fontWeight: "500",
     letterSpacing: 0.2,
+  },
+  statusTextIdle: {
+    color: "#27272A",
+    fontWeight: "600",
   },
 });
 


### PR DESCRIPTION
### Motivation
- Introduce a structured learning card UI to render assistant responses that contain Chinese, pinyin, English, and optional tips in a clean, animated card format.
- Ensure assistant messages display the new card without the default bot bubble chrome so the card styling is preserved.
- Improve readability of the voice stage status text by adjusting color and emphasizing the idle state.

### Description
- Added a new component file `mobile/src/components/StructuredLearningCard.tsx` which exports `StructuredLearningCard` and `parseLearningCard` to parse message text into `{ chinese, pinyin, english, tip }` and render an animated card.
- Updated `mobile/App.tsx` to import `StructuredLearningCard` and `parseLearningCard` and to render `StructuredLearningCard {...parseLearningCard(item.text)}` for assistant messages instead of plain text.
- Adjusted chat bubble styles in `App.tsx` by making `botBubble` transparent and removing padding, border, and shadow so the structured card appears without container chrome.
- Modified `mobile/src/components/VoiceStage.tsx` to change the base `statusText` color and add a `statusTextIdle` style, and apply the idle style when `state === "idle"`.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c424b265148333af732e01f8c65935)