### PR TITLE
Enter-to-send + premium composer UI and structured tutor replies

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -460,7 +460,12 @@ def _build_system_prompt(speaker: Literal["english", "chinese"]) -> str:
         "Keep replies concise, conversational, and tutor-like. "
         "Keep replies to a maximum of 4 lines. "
         "If more info is needed, ask ONE short follow-up question and wait. "
-        "Always include: Chinese, Pinyin, and a short English explanation. "
+        "Always include the actual learning output, never vague placeholders. "
+        "Use this exact structure for teaching replies: "
+        "Chinese: <hanzi output> | "
+        "Pinyin: <tone-marked pinyin> | "
+        "English: <meaning/translation> | "
+        "Example (optional): <one short usage example>. "
         "Do NOT include character breakdowns. "
         "Do NOT include multiple examples or long explanations unless the user asks for more detail. "
         "Provide only one example or tip at a time; do not give multiple examples or tips. "
@@ -471,7 +476,7 @@ def _build_system_prompt(speaker: Literal["english", "chinese"]) -> str:
     if speaker == "english":
         return (
             base
-            + " Explain in English, include Chinese examples, and provide pinyin for Chinese."
+            + " Explain in English. Keep pinyin tone-marked (e.g., nǐ hǎo)."
         )
 
     return (
@@ -480,7 +485,12 @@ def _build_system_prompt(speaker: Literal["english", "chinese"]) -> str:
         "保持简洁、对话式、像导师一样。"
         "每次回复最多4行。"
         "如果需要更多信息，只问一个简短的追问并等待。"
-        "务必包含：中文、拼音、简短英文解释。"
+        "务必给出实际学习内容，不能用“这样说”但不展示答案。"
+        "请用固定格式："
+        "Chinese: <汉字答案>；"
+        "Pinyin: <带声调拼音>；"
+        "English: <英文释义>；"
+        "Example (optional): <一个简短例句>。"
         "不要做汉字拆解。"
         "除非用户要求更多细节，否则不要给多个例子或长解释。"
         "一次只给一个例子或提示，不要给多个。"

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -4,9 +4,11 @@ import * as FileSystem from "expo-file-system/legacy";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
+  NativeSyntheticEvent,
   Animated,
   Easing,
   FlatList,
+  TextInputKeyPressEventData,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -640,6 +642,22 @@ export default function App() {
     } finally {
       setIsSending(false);
     }
+  };
+
+  const handleInputKeyPress = (
+    event: NativeSyntheticEvent<TextInputKeyPressEventData>
+  ) => {
+    if (event.nativeEvent.key !== "Enter") {
+      return;
+    }
+    const nativeEvent = event.nativeEvent as TextInputKeyPressEventData & {
+      shiftKey?: boolean;
+    };
+    if (nativeEvent.shiftKey) {
+      return;
+    }
+    (event as { preventDefault?: () => void }).preventDefault?.();
+    void sendMessage();
   };
 
   const ensureMicPermission = async () => {
@@ -1312,15 +1330,15 @@ export default function App() {
               {
                 borderColor: inputFocusAnim.interpolate({
                   inputRange: [0, 1],
-                  outputRange: ["#FED7AA", "#FDBA74"],
+                  outputRange: ["#EADCC9", "#D7C3AA"],
                 }),
                 shadowOpacity: inputFocusAnim.interpolate({
                   inputRange: [0, 1],
-                  outputRange: [0, 0.2],
+                  outputRange: [0.06, 0.16],
                 }),
                 shadowRadius: inputFocusAnim.interpolate({
                   inputRange: [0, 1],
-                  outputRange: [0, 12],
+                  outputRange: [4, 10],
                 }),
               },
             ]}
@@ -1332,6 +1350,7 @@ export default function App() {
               onChangeText={setInput}
               editable={!isSending}
               multiline
+              onKeyPress={handleInputKeyPress}
               onFocus={() => setIsInputFocused(true)}
               onBlur={() => setIsInputFocused(false)}
             />
@@ -1565,18 +1584,19 @@ const styles = StyleSheet.create({
   },
   inputShell: {
     flex: 1,
-    backgroundColor: "#FFF1DC",
-    borderRadius: 16,
+    backgroundColor: "#FCF8F1",
+    borderRadius: 20,
     borderWidth: 1,
-    borderColor: "#FED7AA",
-    shadowColor: "#F97316",
-    shadowOffset: { width: 0, height: 0 },
+    borderColor: "#EADCC9",
+    shadowColor: "#7C5A35",
+    shadowOffset: { width: 0, height: 2 },
   },
   input: {
     width: "100%",
-    paddingHorizontal: 12,
-    paddingVertical: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
     fontSize: 14,
+    color: "#4A2F1A",
     maxHeight: 120,
   },
   micButton: {
@@ -1600,13 +1620,21 @@ const styles = StyleSheet.create({
   },
   sendButton: {
     marginLeft: 10,
-    backgroundColor: "#B91C1C",
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    borderRadius: 16,
+    backgroundColor: "#8B5E3C",
+    borderWidth: 1,
+    borderColor: "#7A4E2E",
+    paddingHorizontal: 18,
+    paddingVertical: 11,
+    borderRadius: 14,
+    shadowColor: "#6B4428",
+    shadowOpacity: 0.18,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 1,
   },
   sendButtonDisabled: {
-    backgroundColor: "#FCA5A5",
+    backgroundColor: "#CBB9A6",
+    borderColor: "#CBB9A6",
   },
   sendButtonText: {
     color: "#FFFFFF",


### PR DESCRIPTION
### Motivation
- Make the chat composer faster and more natural by sending with Enter while preserving `Shift+Enter` for line breaks.
- Prevent empty/whitespace sends and ensure the composer clears after sending to improve UX.
- Ensure tutor replies are explicit and consistent by forcing responses to include Chinese, tone-marked pinyin, English meaning, and an optional short example.
- Give the input composer a warmer, more premium visual style to reduce the default-browser look and improve polish.

### Description
- Added `handleInputKeyPress` and wired `onKeyPress` on the `TextInput` to send when `Enter` is pressed and not when `Shift` is held, delegating to the existing `sendMessage` flow that trims and clears the input (`mobile/App.tsx`).
- Kept existing guards in `sendMessage` that prevent empty/whitespace-only prompts and that clear `input` after sending (`mobile/App.tsx`).
- Restyled the composer shell and input with a warm off-white background (`#FCF8F1`), softer border colors (`#EADCC9`/`#D7C3AA`), larger corner radius, adjusted padding and text color, and updated the send button to an earth-tone look with softer shadowing for a premium feel (`mobile/App.tsx`).
- Updated the backend system prompt to require an explicit, fixed reply structure and tone-marked pinyin, instructing the model to output: `Chinese: <hanzi>`; `Pinyin: <tone-marked pinyin>`; `English: <meaning>`; `Example (optional): <short example>` instead of vague placeholders (`backend/app/main.py`).

### Testing
- Ran `cd mobile && npx tsc --noEmit`, which completed successfully.
- Ran `cd backend && pytest -q`, which failed during test collection due to existing indentation errors in `backend/tests/test_speech_turn_contract.py` and `backend/tests/test_speech_turn_schema.py` (errors are in test collection, not introduced by these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4346081d48333b231cb13f0e07e7f)