### PR TITLE
Structured beginner reply parsing and repair; add voice-complete UI state and polish mobile UI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import time
 import wave
+import re
 
 import os
 from typing import Literal
@@ -458,14 +459,16 @@ def _build_system_prompt(speaker: Literal["english", "chinese"]) -> str:
         "If the user asks about unrelated topics (politics, health, coding, math, etc.), "
         "politely refuse and redirect them to a language-learning alternative. "
         "Keep replies concise, conversational, and tutor-like. "
-        "Keep replies to a maximum of 4 lines. "
+        "Keep replies to a maximum of 5 lines. "
         "If more info is needed, ask ONE short follow-up question and wait. "
         "Always include the actual learning output, never vague placeholders. "
-        "Use this exact structure for teaching replies: "
-        "Chinese: <hanzi output> | "
-        "Pinyin: <tone-marked pinyin> | "
-        "English: <meaning/translation> | "
-        "Example (optional): <one short usage example>. "
+        "Never reply with only meta teaching text (e.g., 'Here is how to say it') without the answer itself. "
+        "Use Simplified Chinese only. "
+        "For beginner tutoring, output this exact labeled format on separate lines: "
+        "Chinese: <hanzi output> "
+        "Pinyin: <tone-marked pinyin> "
+        "Meaning: <plain English meaning/translation> "
+        "Example (optional): <one short beginner example>. "
         "Do NOT include character breakdowns. "
         "Do NOT include multiple examples or long explanations unless the user asks for more detail. "
         "Provide only one example or tip at a time; do not give multiple examples or tips. "
@@ -483,13 +486,15 @@ def _build_system_prompt(speaker: Literal["english", "chinese"]) -> str:
         "你是一位中文导师。你的任务仅限于中文↔英文学习：翻译、词汇、语法、发音（拼音）与例句。"
         "如果用户问与语言学习无关的话题（政治、健康、编程、数学等），请礼貌拒绝，并引导回到语言学习任务（例如翻译一句话、解释一个短语）。"
         "保持简洁、对话式、像导师一样。"
-        "每次回复最多4行。"
+        "每次回复最多5行。"
         "如果需要更多信息，只问一个简短的追问并等待。"
         "务必给出实际学习内容，不能用“这样说”但不展示答案。"
+        "禁止只给泛泛教学话术，必须给出具体中文答案。"
+        "只使用简体中文。"
         "请用固定格式："
-        "Chinese: <汉字答案>；"
-        "Pinyin: <带声调拼音>；"
-        "English: <英文释义>；"
+        "Chinese: <汉字答案>"
+        "Pinyin: <带声调拼音>"
+        "Meaning: <英文释义>"
         "Example (optional): <一个简短例句>。"
         "不要做汉字拆解。"
         "除非用户要求更多细节，否则不要给多个例子或长解释。"
@@ -497,6 +502,72 @@ def _build_system_prompt(speaker: Literal["english", "chinese"]) -> str:
         "把教学拆成多轮对话，每次只讲一个点。"
         "大多数回复以简短可选的引导结尾（例如“要例句吗？/要练习吗？/要更口语的版本吗？”）。"
     )
+
+
+HAN_REGEX = re.compile(r"[\u3400-\u9FFF]")
+TONE_MARK_REGEX = re.compile(r"[āáǎàēéěèīíǐìōóǒòūúǔùǖǘǚǜ]", re.IGNORECASE)
+
+
+def _extract_labeled_value(text: str, label: str) -> str:
+    match = re.search(rf"(?im)^\s*(?:{label})\s*:\s*(.+?)\s*$", text)
+    return (match.group(1).strip() if match else "")
+
+
+def _is_structured_beginner_reply(text: str) -> bool:
+    chinese = _extract_labeled_value(text, "chinese")
+    pinyin = _extract_labeled_value(text, "pinyin")
+    meaning = _extract_labeled_value(text, "meaning|english|translation")
+    return bool(
+        chinese
+        and pinyin
+        and meaning
+        and HAN_REGEX.search(chinese)
+        and TONE_MARK_REGEX.search(pinyin)
+    )
+
+
+def _normalize_structured_reply(text: str) -> str:
+    chinese = _extract_labeled_value(text, "chinese")
+    pinyin = _extract_labeled_value(text, "pinyin")
+    meaning = _extract_labeled_value(text, "meaning|english|translation")
+    example = _extract_labeled_value(text, "example")
+
+    lines = [
+        f"Chinese: {chinese}",
+        f"Pinyin: {pinyin}",
+        f"Meaning: {meaning}",
+    ]
+    if example:
+        lines.append(f"Example: {example}")
+    return "\n".join(lines)
+
+
+async def _generate_chat_reply(
+    client: httpx.AsyncClient, api_key: str, payload: dict
+) -> str:
+    response = await client.post(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
+        headers={
+            "Content-Type": "application/json",
+        },
+        params={"key": api_key},
+        json=payload,
+    )
+    if response.status_code != 200:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Gemini error: {response.status_code}: {response.text}",
+        )
+    data = response.json()
+    content = (
+        data.get("candidates", [{}])[0]
+        .get("content", {})
+        .get("parts", [{}])[0]
+        .get("text")
+    )
+    if not content:
+        raise HTTPException(status_code=502, detail="Gemini returned no content.")
+    return content
 
 
 @app.post("/chat", response_model=ChatResponse)
@@ -535,33 +606,57 @@ async def llm_chat(
         ],
     }
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.post(
-            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
-            headers={
-                "Content-Type": "application/json",
-            },
-            params={"key": api_key},
-            json=payload,
-        )
-
-    if response.status_code != 200:
-        raise HTTPException(
-            status_code=502,
-            detail=f"Gemini error: {response.status_code}: {response.text}",
-        )
-
-    data = response.json()
-    content = (
-        data.get("candidates", [{}])[0]
-        .get("content", {})
-        .get("parts", [{}])[0]
-        .get("text")
+    last_user_message = next(
+        (message.content for message in reversed(request.messages) if message.role == "user"),
+        "",
     )
-    if not content:
-        raise HTTPException(status_code=502, detail="Gemini returned no content.")
 
-    return LLMChatResponse(reply=content)
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        content = await _generate_chat_reply(client=client, api_key=api_key, payload=payload)
+
+        if not _is_structured_beginner_reply(content):
+            repair_payload = {
+                "systemInstruction": {
+                    "parts": [
+                        {
+                            "text": (
+                                "Rewrite into strict beginner Chinese tutoring format. "
+                                "Return only these lines: "
+                                "Chinese: ...\n"
+                                "Pinyin: ...\n"
+                                "Meaning: ...\n"
+                                "Example: ... (optional)\n"
+                                "Rules: include concrete Simplified Chinese answer, tone-marked pinyin, and plain English meaning. "
+                                "No vague text."
+                            )
+                        }
+                    ]
+                },
+                "generationConfig": {"maxOutputTokens": 160, "temperature": 0.1},
+                "contents": [
+                    {
+                        "role": "user",
+                        "parts": [
+                            {
+                                "text": (
+                                    f"User question: {last_user_message}\n"
+                                    f"Draft answer to fix:\n{content}"
+                                )
+                            }
+                        ],
+                    }
+                ],
+            }
+            repaired = await _generate_chat_reply(
+                client=client, api_key=api_key, payload=repair_payload
+            )
+            content = repaired if _is_structured_beginner_reply(repaired) else (
+                "Chinese: 请告诉我你想表达的英文句子。\n"
+                "Pinyin: Qǐng gàosu wǒ nǐ xiǎng biǎodá de Yīngwén jùzi.\n"
+                "Meaning: Please tell me the English sentence you want to say."
+            )
+
+    return LLMChatResponse(reply=_normalize_structured_reply(content))
 
 
 async def _speech_turn_handler(

--- a/backend/tests/test_chat_reply_format.py
+++ b/backend/tests/test_chat_reply_format.py
@@ -1,0 +1,30 @@
+from app.main import (
+    _is_structured_beginner_reply,
+    _normalize_structured_reply,
+)
+
+
+def test_is_structured_beginner_reply_accepts_valid_format() -> None:
+    text = (
+        "Chinese: 一，二，三\n"
+        "Pinyin: yī, èr, sān\n"
+        "Meaning: 1, 2, 3\n"
+    )
+    assert _is_structured_beginner_reply(text) is True
+
+
+def test_is_structured_beginner_reply_rejects_vague_text() -> None:
+    text = "Here's how to say 1, 2, 3 in Chinese."
+    assert _is_structured_beginner_reply(text) is False
+
+
+def test_normalize_structured_reply_converts_english_label_to_meaning() -> None:
+    text = (
+        "Chinese: 你好\n"
+        "Pinyin: nǐ hǎo\n"
+        "English: hello\n"
+        "Example: 你好，老师。\n"
+    )
+    normalized = _normalize_structured_reply(text)
+    assert "Meaning: hello" in normalized
+    assert "English:" not in normalized

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -146,10 +146,34 @@ const TypingIndicator = () => {
           ]}
         />
       ))}
-      <Text style={styles.typingText}>Thinking...</Text>
+      <Text style={styles.typingText}>Translating your phrase...</Text>
     </View>
   );
 };
+
+const LoadingState = ({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle: string;
+}) => (
+  <SafeAreaView style={styles.loadingContainer}>
+    <ActivityIndicator size="large" color="#A16207" />
+    <Text style={styles.loadingTitle}>{title}</Text>
+    <Text style={styles.loadingSubtitle}>{subtitle}</Text>
+  </SafeAreaView>
+);
+
+const EmptyChatState = () => (
+  <View style={styles.emptyStateCard}>
+    <Text style={styles.emptyStateEyebrow}>Start learning</Text>
+    <Text style={styles.emptyStateTitle}>Say one phrase out loud or type one.</Text>
+    <Text style={styles.emptyStateBody}>
+      Try: “How do I say nice to meet you?” or “1, 2, 3 in Chinese.”
+    </Text>
+  </View>
+);
 
 const MessageBubble = ({ item }: { item: ChatMessage }) => {
   const entrance = useRef(new Animated.Value(0)).current;
@@ -332,6 +356,7 @@ export default function App() {
   const [isRecording, setIsRecording] = useState(false);
   const [isUploadingVoice, setIsUploadingVoice] = useState(false);
   const [isPlayingPronunciation, setIsPlayingPronunciation] = useState(false);
+  const [showVoiceComplete, setShowVoiceComplete] = useState(false);
   const [voiceError, setVoiceError] = useState<string | null>(null);
   const [voiceTurn, setVoiceTurn] = useState<SpeechTurnResponse | null>(null);
   const [selectedVoice, setSelectedVoice] = useState<VoiceOption>("warm");
@@ -339,6 +364,7 @@ export default function App() {
   const listRef = useRef<FlatList<ChatMessage>>(null);
   const recordingRef = useRef<Audio.Recording | null>(null);
   const soundRef = useRef<Audio.Sound | null>(null);
+  const completeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputFocusAnim = useRef(new Animated.Value(0)).current;
   const sendBurstAnim = useRef(new Animated.Value(0)).current;
   const stageTransition = useRef(new Animated.Value(0)).current;
@@ -784,6 +810,11 @@ export default function App() {
       );
       return;
     }
+    if (completeTimeoutRef.current) {
+      clearTimeout(completeTimeoutRef.current);
+      completeTimeoutRef.current = null;
+    }
+    setShowVoiceComplete(false);
     setVoiceError(null);
     if (soundRef.current) {
       await soundRef.current.stopAsync();
@@ -811,6 +842,7 @@ export default function App() {
     }
     setIsRecording(false);
     setIsUploadingVoice(true);
+    setShowVoiceComplete(false);
     setIsPlayingPronunciation(false);
     setVoiceError(null);
     try {
@@ -864,6 +896,14 @@ export default function App() {
       const data = JSON.parse(raw) as SpeechTurnResponse;
       console.log("Voice Response Payload:", data);
       setVoiceTurn(data);
+      setShowVoiceComplete(true);
+      if (completeTimeoutRef.current) {
+        clearTimeout(completeTimeoutRef.current);
+      }
+      completeTimeoutRef.current = setTimeout(() => {
+        setShowVoiceComplete(false);
+        completeTimeoutRef.current = null;
+      }, 2400);
       const audioPayload = data.audio ?? {
         format: data.audio_mime?.includes("mpeg") ? "mp3" : "wav",
         url: data.audio_url ?? undefined,
@@ -906,6 +946,8 @@ export default function App() {
     ? "processing"
     : isPlayingPronunciation
     ? "speaking"
+    : showVoiceComplete
+    ? "complete"
     : "idle";
 
   useEffect(() => {
@@ -925,7 +967,9 @@ export default function App() {
         ? 1
         : voiceStageState === "processing"
         ? 2
-        : 3;
+        : voiceStageState === "speaking"
+        ? 3
+        : 4;
     Animated.timing(stageTransition, {
       toValue: next,
       duration: 320,
@@ -933,6 +977,14 @@ export default function App() {
       useNativeDriver: true,
     }).start();
   }, [stageTransition, voiceStageState]);
+
+  useEffect(() => {
+    return () => {
+      if (completeTimeoutRef.current) {
+        clearTimeout(completeTimeoutRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     ambientDriftA.setValue(0);
@@ -1029,15 +1081,12 @@ export default function App() {
 
   const micButton = useMicroButton();
   const sendButton = useMicroButton();
+  const canSend = input.trim().length > 0 && !isSending;
 
   const renderItem = ({ item }: { item: ChatMessage }) => <MessageBubble item={item} />;
 
   if (isLoadingAppLock) {
-    return (
-      <SafeAreaView style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color="#2F6FED" />
-      </SafeAreaView>
-    );
+    return <LoadingState title="Preparing your tutor" subtitle="One quick moment..." />;
   }
 
   if (!isAppUnlocked) {
@@ -1049,11 +1098,7 @@ export default function App() {
   }
 
   if (isBootstrapping) {
-    return (
-      <SafeAreaView style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color="#2F6FED" />
-      </SafeAreaView>
-    );
+    return <LoadingState title="Connecting" subtitle="Setting up your learning session..." />;
   }
 
   if (
@@ -1072,11 +1117,7 @@ export default function App() {
   }
 
   if (isLoadingPreference) {
-    return (
-      <SafeAreaView style={styles.loadingContainer}>
-        <ActivityIndicator size="large" color="#2F6FED" />
-      </SafeAreaView>
-    );
+    return <LoadingState title="Loading preferences" subtitle="Restoring your tutor mode..." />;
   }
 
   if (!preference) {
@@ -1318,6 +1359,7 @@ export default function App() {
           keyExtractor={(item) => item.id}
           renderItem={renderItem}
           contentContainerStyle={styles.messagesContent}
+          ListEmptyComponent={<EmptyChatState />}
           onContentSizeChange={() =>
             listRef.current?.scrollToEnd({ animated: true })
           }
@@ -1330,22 +1372,27 @@ export default function App() {
               {
                 borderColor: inputFocusAnim.interpolate({
                   inputRange: [0, 1],
-                  outputRange: ["#EADCC9", "#D7C3AA"],
+                  outputRange: ["#E7DAC8", "#CFB79A"],
                 }),
                 shadowOpacity: inputFocusAnim.interpolate({
                   inputRange: [0, 1],
-                  outputRange: [0.06, 0.16],
+                  outputRange: [0.03, 0.1],
                 }),
                 shadowRadius: inputFocusAnim.interpolate({
                   inputRange: [0, 1],
-                  outputRange: [4, 10],
+                  outputRange: [5, 12],
                 }),
               },
             ]}
           >
             <TextInput
-              style={styles.input}
-              placeholder="Type in English, 中文, or both"
+              style={[
+                styles.input,
+                Platform.OS === "web" ? ({ outlineWidth: 0 } as never) : null,
+              ]}
+              placeholder="Write your phrase in English or 中文"
+              placeholderTextColor="#A48768"
+              selectionColor="#A06B43"
               value={input}
               onChangeText={setInput}
               editable={!isSending}
@@ -1384,14 +1431,17 @@ export default function App() {
               }}
             >
               <Pressable
-                style={[styles.sendButton, isSending && styles.sendButtonDisabled]}
+                style={[
+                  styles.sendButton,
+                  (!canSend || isSending) && styles.sendButtonDisabled,
+                ]}
                 onPress={sendMessage}
-                disabled={isSending}
+                disabled={!canSend || isSending}
                 {...sendButton.handlers}
               >
-                <Animated.Text
+                <Animated.View
                   style={[
-                    styles.sendButtonText,
+                    styles.sendButtonContent,
                     {
                       transform: [
                         {
@@ -1408,8 +1458,9 @@ export default function App() {
                     },
                   ]}
                 >
-                  {isSending ? "..." : "Send"}
-                </Animated.Text>
+                  <Text style={styles.sendButtonIcon}>➤</Text>
+                  <Text style={styles.sendButtonText}>{isSending ? "Sending" : "Send"}</Text>
+                </Animated.View>
               </Pressable>
             </Animated.View>
           </Animated.View>
@@ -1464,6 +1515,21 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
+    paddingHorizontal: 24,
+    backgroundColor: "#FDF8F2",
+  },
+  loadingTitle: {
+    marginTop: 14,
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#7C2D12",
+  },
+  loadingSubtitle: {
+    marginTop: 6,
+    fontSize: 13,
+    lineHeight: 18,
+    color: "#9A5A2B",
+    textAlign: "center",
   },
   headerHero: {
     paddingHorizontal: 20,
@@ -1516,25 +1582,61 @@ const styles = StyleSheet.create({
     fontWeight: "600",
   },
   messagesContent: {
+    flexGrow: 1,
     paddingHorizontal: 20,
+    paddingTop: 14,
+    paddingBottom: 20,
+    gap: 6,
+  },
+  emptyStateCard: {
+    marginTop: 16,
+    backgroundColor: "rgba(255, 253, 249, 0.95)",
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: "#EEDCC7",
+    paddingHorizontal: 16,
     paddingVertical: 16,
+    shadowColor: "#A16207",
+    shadowOpacity: 0.06,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+  },
+  emptyStateEyebrow: {
+    fontSize: 11,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    color: "#B45309",
+    fontWeight: "700",
+  },
+  emptyStateTitle: {
+    marginTop: 6,
+    fontSize: 16,
+    lineHeight: 22,
+    fontWeight: "700",
+    color: "#7C2D12",
+  },
+  emptyStateBody: {
+    marginTop: 8,
+    fontSize: 13,
+    lineHeight: 20,
+    color: "#9A5A2B",
   },
   messageBubble: {
-    borderRadius: 16,
-    paddingHorizontal: 14,
-    paddingVertical: 10,
-    marginBottom: 12,
-    maxWidth: "85%",
+    borderRadius: 18,
+    paddingHorizontal: 15,
+    paddingVertical: 11,
+    marginBottom: 8,
+    maxWidth: "88%",
     borderWidth: 1,
   },
   userBubble: {
-    backgroundColor: "#FFF9F3",
-    borderColor: "#FED7AA",
+    backgroundColor: "#FFF7ED",
+    borderColor: "#FCD9B1",
     alignSelf: "flex-end",
     shadowColor: "#A16207",
-    shadowOpacity: 0.06,
-    shadowRadius: 6,
-    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 3 },
     elevation: 1,
   },
   botBubble: {
@@ -1550,7 +1652,8 @@ const styles = StyleSheet.create({
   userText: {
     color: "#7C2D12",
     fontSize: 14,
-    lineHeight: 20,
+    lineHeight: 21,
+    fontWeight: "500",
   },
   botText: {
     color: "#581C87",
@@ -1570,7 +1673,7 @@ const styles = StyleSheet.create({
   },
   typingText: {
     marginLeft: 6,
-    color: "#6B21A8",
+    color: "#7E22CE",
     fontSize: 12,
     fontWeight: "500",
   },
@@ -1578,26 +1681,32 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "flex-end",
     paddingHorizontal: 16,
-    paddingVertical: 12,
+    paddingTop: 10,
+    paddingBottom: 12,
+    backgroundColor: "#F9F2E8",
     borderTopWidth: 1,
-    borderTopColor: "#F5D0A9",
+    borderTopColor: "#EEDCC7",
   },
   inputShell: {
     flex: 1,
-    backgroundColor: "#FCF8F1",
-    borderRadius: 20,
+    backgroundColor: "#FFFDF9",
+    borderRadius: 22,
     borderWidth: 1,
-    borderColor: "#EADCC9",
-    shadowColor: "#7C5A35",
-    shadowOffset: { width: 0, height: 2 },
+    borderColor: "#E7DAC8",
+    shadowColor: "#8A6648",
+    shadowOffset: { width: 0, height: 3 },
+    shadowRadius: 6,
+    elevation: 1,
   },
   input: {
     width: "100%",
-    paddingHorizontal: 14,
-    paddingVertical: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
     fontSize: 14,
     color: "#4A2F1A",
+    lineHeight: 20,
     maxHeight: 120,
+    minHeight: 46,
   },
   micButton: {
     marginLeft: 8,
@@ -1620,26 +1729,41 @@ const styles = StyleSheet.create({
   },
   sendButton: {
     marginLeft: 10,
-    backgroundColor: "#8B5E3C",
+    minHeight: 44,
+    minWidth: 88,
+    backgroundColor: "#8F5A33",
     borderWidth: 1,
-    borderColor: "#7A4E2E",
-    paddingHorizontal: 18,
-    paddingVertical: 11,
-    borderRadius: 14,
+    borderColor: "#7B4925",
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 16,
     shadowColor: "#6B4428",
-    shadowOpacity: 0.18,
-    shadowRadius: 8,
+    shadowOpacity: 0.16,
+    shadowRadius: 7,
     shadowOffset: { width: 0, height: 3 },
     elevation: 1,
+    justifyContent: "center",
   },
   sendButtonDisabled: {
-    backgroundColor: "#CBB9A6",
-    borderColor: "#CBB9A6",
+    backgroundColor: "#CCBBA8",
+    borderColor: "#CCBBA8",
+  },
+  sendButtonContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+  },
+  sendButtonIcon: {
+    color: "#FFFFFF",
+    fontSize: 12,
+    marginTop: -1,
   },
   sendButtonText: {
     color: "#FFFFFF",
-    fontWeight: "600",
+    fontWeight: "700",
     fontSize: 14,
+    letterSpacing: 0.2,
   },
   errorBanner: {
     backgroundColor: "#FEE2E2",

--- a/mobile/src/components/StructuredLearningCard.tsx
+++ b/mobile/src/components/StructuredLearningCard.tsx
@@ -23,14 +23,14 @@ export const parseLearningCard = (text: string) => {
   const taggedEnglish = normalized.find(
     (line) => /^(english|meaning|translation)\s*:/i.test(line)
   );
-  const taggedTip = normalized.find((line) => /^tip\s*:/i.test(line));
+  const taggedTip = normalized.find((line) => /^(tip|example|note)\s*:/i.test(line));
 
   const chineseFromTag = taggedChinese?.replace(/^chinese\s*:/i, "").trim();
   const pinyinFromTag = taggedPinyin?.replace(/^pinyin\s*:/i, "").trim();
   const englishFromTag = taggedEnglish
     ?.replace(/^(english|meaning|translation)\s*:/i, "")
     .trim();
-  const tipFromTag = taggedTip?.replace(/^tip\s*:/i, "").trim();
+  const tipFromTag = taggedTip?.replace(/^(tip|example|note)\s*:/i, "").trim();
 
   const chineseFallback =
     normalized.find((line) => HAN_REGEX.test(line) && line.length <= 40) ?? "";
@@ -90,13 +90,21 @@ const StructuredLearningCard = ({
 
   return (
     <Animated.View style={[styles.card, cardStyle]}>
+      <Text style={styles.sectionLabel}>Chinese</Text>
       <Text style={styles.chinese}>{chinese}</Text>
-      {pinyin ? <Text style={styles.pinyin}>{pinyin}</Text> : null}
-      <Text style={styles.english}>{english}</Text>
+      {pinyin ? (
+        <View style={styles.pinyinChip}>
+          <Text style={styles.pinyin}>{pinyin}</Text>
+        </View>
+      ) : null}
+      <View style={styles.meaningBlock}>
+        <Text style={styles.meaningLabel}>Meaning</Text>
+        <Text style={styles.english}>{english}</Text>
+      </View>
 
       {tip ? (
         <View style={styles.tipBox}>
-          <Text style={styles.tipTitle}>💡 Tip</Text>
+          <Text style={styles.tipTitle}>💡 Example</Text>
           <Text style={styles.tipText}>{tip}</Text>
         </View>
       ) : null}
@@ -109,55 +117,88 @@ const styles = StyleSheet.create({
   card: {
     borderRadius: 18,
     paddingHorizontal: 16,
-    paddingVertical: 16,
-    backgroundColor: "rgba(255, 255, 255, 0.92)",
+    paddingVertical: 18,
+    backgroundColor: "rgba(255, 255, 255, 0.96)",
     borderWidth: 1,
-    borderColor: "rgba(232, 213, 255, 0.95)",
-    shadowColor: "#7E22CE",
-    shadowOpacity: 0.14,
+    borderColor: "rgba(228, 209, 183, 0.95)",
+    shadowColor: "#8B5A2B",
+    shadowOpacity: 0.1,
     shadowOffset: { width: 0, height: 8 },
-    shadowRadius: 16,
+    shadowRadius: 18,
     elevation: 3,
-    gap: 8,
+    gap: 10,
+  },
+  sectionLabel: {
+    fontSize: 11,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    fontWeight: "700",
+    color: "#A16207",
+    textAlign: "center",
   },
   chinese: {
-    fontSize: 30,
-    lineHeight: 38,
-    fontWeight: "700",
+    fontSize: 38,
+    lineHeight: 44,
+    fontWeight: "800",
     color: "#3B0764",
     textAlign: "center",
+    marginTop: -2,
+  },
+  pinyinChip: {
+    alignSelf: "center",
+    borderRadius: 999,
+    backgroundColor: "#F7EDFF",
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderWidth: 1,
+    borderColor: "#E9D5FF",
   },
   pinyin: {
     fontSize: 15,
     lineHeight: 20,
     textAlign: "center",
-    color: "#7E22CE",
+    color: "#6B21A8",
+    fontWeight: "500",
+  },
+  meaningBlock: {
+    borderTopWidth: 1,
+    borderTopColor: "#F1E4CF",
+    paddingTop: 10,
+    alignItems: "center",
+    gap: 4,
+  },
+  meaningLabel: {
+    fontSize: 11,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    color: "#A8A29E",
+    fontWeight: "700",
   },
   english: {
     fontSize: 14,
-    lineHeight: 20,
+    lineHeight: 21,
     color: "#6B7280",
     textAlign: "center",
   },
   tipBox: {
-    marginTop: 4,
-    backgroundColor: "#FAF5FF",
+    marginTop: 2,
+    backgroundColor: "#FFF7ED",
     borderRadius: 12,
     paddingHorizontal: 12,
     paddingVertical: 10,
     borderWidth: 1,
-    borderColor: "#E9D5FF",
+    borderColor: "#FED7AA",
   },
   tipTitle: {
     fontSize: 12,
     fontWeight: "700",
-    color: "#6B21A8",
+    color: "#9A3412",
     marginBottom: 4,
   },
   tipText: {
     fontSize: 13,
     lineHeight: 18,
-    color: "#6D28D9",
+    color: "#7C2D12",
   },
 });
 

--- a/mobile/src/components/VoiceStage.tsx
+++ b/mobile/src/components/VoiceStage.tsx
@@ -8,7 +8,12 @@ import {
   View,
 } from "react-native";
 
-export type VoiceStageState = "idle" | "listening" | "processing" | "speaking";
+export type VoiceStageState =
+  | "idle"
+  | "listening"
+  | "processing"
+  | "speaking"
+  | "complete";
 export type VoiceTone = "warm" | "bright" | "deep";
 
 type VoiceStageProps = {
@@ -23,8 +28,9 @@ type VoiceStageProps = {
 const statusTextByState: Record<VoiceStageState, string> = {
   idle: "Tap and hold to speak",
   listening: "Listening...",
-  processing: "Thinking...",
+  processing: "Translating...",
   speaking: "Playing pronunciation...",
+  complete: "Complete ✓",
 };
 
 const VoiceStage = ({
@@ -47,7 +53,15 @@ const VoiceStage = ({
 
   useEffect(() => {
     const nextState =
-      state === "idle" ? 0 : state === "listening" ? 1 : state === "processing" ? 2 : 3;
+      state === "idle"
+        ? 0
+        : state === "listening"
+        ? 1
+        : state === "processing"
+        ? 2
+        : state === "speaking"
+        ? 3
+        : 4;
     Animated.timing(stateMorph, {
       toValue: nextState,
       duration: 280,
@@ -272,14 +286,14 @@ const VoiceStage = ({
             borderWidth: 1,
             borderColor: "rgba(255,255,255,0.12)",
             opacity: stateMorph.interpolate({
-              inputRange: [0, 1, 2, 3],
-              outputRange: [0.08, 0.16, 0.2, 0.14],
+              inputRange: [0, 1, 2, 3, 4],
+              outputRange: [0.08, 0.16, 0.2, 0.14, 0.22],
             }),
             transform: [
               {
                 scale: stateMorph.interpolate({
-                  inputRange: [0, 1, 2, 3],
-                  outputRange: [1, 1.03, 1.04, 1.02],
+                  inputRange: [0, 1, 2, 3, 4],
+                  outputRange: [1, 1.03, 1.04, 1.02, 1.05],
                 }),
               },
             ],
@@ -370,6 +384,31 @@ const VoiceStage = ({
             </View>
           ) : null}
 
+          {state === "complete" ? (
+            <Animated.View
+              style={[
+                styles.completeRing,
+                {
+                  width: ringSize - 2,
+                  height: ringSize - 2,
+                  borderColor: ringAccentColor,
+                  opacity: stateMorph.interpolate({
+                    inputRange: [3, 4],
+                    outputRange: [0.2, 0.85],
+                  }),
+                  transform: [
+                    {
+                      scale: stateMorph.interpolate({
+                        inputRange: [3, 4],
+                        outputRange: [0.96, 1.02],
+                      }),
+                    },
+                  ],
+                },
+              ]}
+            />
+          ) : null}
+
           <Animated.View
             style={[
               styles.orb,
@@ -435,14 +474,14 @@ const VoiceStage = ({
           state === "idle" ? styles.statusTextIdle : null,
           {
             opacity: stateMorph.interpolate({
-              inputRange: [0, 1, 2, 3],
-              outputRange: [0.9, 1, 0.96, 0.94],
+              inputRange: [0, 1, 2, 3, 4],
+              outputRange: [0.9, 1, 0.96, 0.94, 1],
             }),
             transform: [
               {
                 translateY: stateMorph.interpolate({
-                  inputRange: [0, 1, 2, 3],
-                  outputRange: [0, -1, -1, 0],
+                  inputRange: [0, 1, 2, 3, 4],
+                  outputRange: [0, -1, -1, 0, -1],
                 }),
               },
             ],
@@ -527,6 +566,14 @@ const styles = StyleSheet.create({
     position: "absolute",
     borderRadius: 999,
     borderWidth: 2,
+  },
+  completeRing: {
+    position: "absolute",
+    borderRadius: 999,
+    borderWidth: 2,
+    shadowOpacity: 0.35,
+    shadowRadius: 7,
+    shadowOffset: { width: 0, height: 0 },
   },
   segmentRing: {
     position: "absolute",


### PR DESCRIPTION
### Motivation

- Ensure LLM output conforms to a strict beginner-friendly format (Chinese, Pinyin, Meaning, optional Example) and automatically repair nonconforming Gemini responses. 
- Surface a brief "complete" state for voice turns in the mobile UI and improve overall messaging/input UX and styling.

### Description

- Add parsing, validation and normalization helpers in `backend/app/main.py` (`_extract_labeled_value`, `_is_structured_beginner_reply`, `_normalize_structured_reply`) and wrap Gemini calls with `_generate_chat_reply` and a repair pass that re-requests a cleaned beginner-formatted answer when needed. 
- Tighten and extend the system prompt wording for beginner tutoring and enforce Simplified Chinese and labeled output in the prompt text. 
- Add a unit test file `backend/tests/test_chat_reply_format.py` that verifies structured reply detection and normalization. 
- Mobile/UI changes: update typing text, add `LoadingState` and `EmptyChatState`, show a transient voice-complete state with `showVoiceComplete` and timeout handling, add `canSend` logic to disable send when input is empty, update input placeholder/colors/selection, change send button layout/content, add `ListEmptyComponent`, refine many styles, and update `VoiceStage` and `StructuredLearningCard` to support the new "complete" voice state and improved learning card layout.

### Testing

- Ran unit tests for the backend parsing helpers with `pytest backend/tests/test_chat_reply_format.py`, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c435cc04308333a9170360422cf121)