### PR TITLE
Refactor VoiceStage animations: separate native/JS drivers and remove animated shadows

### DIFF
--- a/mobile/src/components/VoiceStage.tsx
+++ b/mobile/src/components/VoiceStage.tsx
@@ -33,6 +33,25 @@ const statusTextByState: Record<VoiceStageState, string> = {
   complete: "Complete ✓",
 };
 
+const modeToNumeric = (mode: VoiceTone) =>
+  mode === "warm" ? 0 : mode === "bright" ? 1 : 2;
+
+const stateToNumeric = (state: VoiceStageState) => {
+  if (state === "idle") {
+    return 0;
+  }
+  if (state === "listening") {
+    return 1;
+  }
+  if (state === "processing") {
+    return 2;
+  }
+  if (state === "speaking") {
+    return 3;
+  }
+  return 4;
+};
+
 const VoiceStage = ({
   state,
   mode,
@@ -41,69 +60,60 @@ const VoiceStage = ({
   disabled = false,
   size = 64,
 }: VoiceStageProps) => {
-  const breathing = useRef(new Animated.Value(0)).current;
-  const pressScale = useRef(new Animated.Value(0)).current;
-  const ringPulse = useRef(new Animated.Value(0)).current;
-  const ringSpin = useRef(new Animated.Value(0)).current;
-  const speakingShimmer = useRef(new Animated.Value(0)).current;
-  const stateMorph = useRef(new Animated.Value(0)).current;
-  const modeTransitionNative = useRef(
-    new Animated.Value(mode === "warm" ? 0 : mode === "bright" ? 1 : 2)
-  ).current;
-  const modeTransitionColor = useRef(
-    new Animated.Value(mode === "warm" ? 0 : mode === "bright" ? 1 : 2)
-  ).current;
-  const pressGlowBoost = useRef(new Animated.Value(0)).current;
+  // Native-driver-only values (opacity/transform only)
+  const stateNative = useRef(new Animated.Value(stateToNumeric(state))).current;
+  const modeNative = useRef(new Animated.Value(modeToNumeric(mode))).current;
+  const breathingNative = useRef(new Animated.Value(0)).current;
+  const pressNative = useRef(new Animated.Value(0)).current;
+  const listeningRingNative = useRef(new Animated.Value(0)).current;
+  const processingSpinNative = useRef(new Animated.Value(0)).current;
+  const speakingWaveNative = useRef(new Animated.Value(0)).current;
+
+  // JS-driver-only values (color interpolation and any non-native compatible math)
+  const modeColor = useRef(new Animated.Value(modeToNumeric(mode))).current;
+  const glowBoostColor = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
-    const nextState =
-      state === "idle"
-        ? 0
-        : state === "listening"
-        ? 1
-        : state === "processing"
-        ? 2
-        : state === "speaking"
-        ? 3
-        : 4;
-    Animated.timing(stateMorph, {
-      toValue: nextState,
+    Animated.timing(stateNative, {
+      toValue: stateToNumeric(state),
       duration: 280,
       easing: Easing.inOut(Easing.cubic),
       useNativeDriver: true,
     }).start();
-  }, [state, stateMorph]);
+  }, [state, stateNative]);
 
   useEffect(() => {
-    const targetMode = mode === "warm" ? 0 : mode === "bright" ? 1 : 2;
-    const nativeTransition = Animated.timing(modeTransitionNative, {
-      toValue: targetMode,
+    Animated.timing(modeNative, {
+      toValue: modeToNumeric(mode),
       duration: 620,
       easing: Easing.inOut(Easing.cubic),
       useNativeDriver: true,
-    });
-    const colorTransition = Animated.timing(modeTransitionColor, {
-      toValue: targetMode,
+    }).start();
+  }, [mode, modeNative]);
+
+  useEffect(() => {
+    Animated.timing(modeColor, {
+      toValue: modeToNumeric(mode),
       duration: 620,
       easing: Easing.inOut(Easing.cubic),
       useNativeDriver: false,
-    });
-    Animated.parallel([nativeTransition, colorTransition]).start();
-  }, [mode, modeTransitionColor, modeTransitionNative]);
+    }).start();
+  }, [mode, modeColor]);
 
   useEffect(() => {
     const inhaleExhaleDuration =
       mode === "bright" ? 1200 : mode === "warm" ? 2200 : 2800;
 
+    breathingNative.setValue(0);
     const loop = Animated.loop(
       Animated.sequence([
-        Animated.timing(breathing, {
+        Animated.timing(breathingNative, {
           toValue: 1,
           duration: inhaleExhaleDuration,
           useNativeDriver: true,
           easing: Easing.inOut(Easing.ease),
         }),
-        Animated.timing(breathing, {
+        Animated.timing(breathingNative, {
           toValue: 0,
           duration: inhaleExhaleDuration,
           useNativeDriver: true,
@@ -111,29 +121,36 @@ const VoiceStage = ({
         }),
       ])
     );
+
     loop.start();
-    return () => loop.stop();
-  }, [breathing, mode]);
+    return () => {
+      loop.stop();
+      breathingNative.stopAnimation();
+    };
+  }, [mode, breathingNative]);
 
   useEffect(() => {
-    Animated.spring(pressScale, {
+    Animated.spring(pressNative, {
       toValue: state === "listening" ? 1 : 0,
       friction: 7,
       tension: 180,
       useNativeDriver: true,
     }).start();
-    Animated.spring(pressGlowBoost, {
+  }, [state, pressNative]);
+
+  useEffect(() => {
+    Animated.spring(glowBoostColor, {
       toValue: state === "listening" ? 1 : 0,
       friction: 8,
       tension: 170,
       useNativeDriver: false,
     }).start();
-  }, [pressGlowBoost, pressScale, state]);
+  }, [state, glowBoostColor]);
 
   useEffect(() => {
     if (state !== "listening") {
-      ringPulse.stopAnimation();
-      ringPulse.setValue(0);
+      listeningRingNative.stopAnimation();
+      listeningRingNative.setValue(0);
       return;
     }
 
@@ -143,13 +160,13 @@ const VoiceStage = ({
 
     const loop = Animated.loop(
       Animated.sequence([
-        Animated.timing(ringPulse, {
+        Animated.timing(listeningRingNative, {
           toValue: 1,
           duration: riseDuration,
           useNativeDriver: true,
           easing: Easing.out(Easing.cubic),
         }),
-        Animated.timing(ringPulse, {
+        Animated.timing(listeningRingNative, {
           toValue: settleFloor,
           duration: settleDuration,
           useNativeDriver: true,
@@ -157,137 +174,156 @@ const VoiceStage = ({
         }),
       ])
     );
+
     loop.start();
-    return () => loop.stop();
-  }, [mode, ringPulse, state]);
+    return () => {
+      loop.stop();
+      listeningRingNative.stopAnimation();
+    };
+  }, [state, mode, listeningRingNative]);
 
   useEffect(() => {
     if (state !== "processing") {
-      ringSpin.stopAnimation();
-      ringSpin.setValue(0);
+      processingSpinNative.stopAnimation();
+      processingSpinNative.setValue(0);
       return;
     }
 
     const loop = Animated.loop(
-      Animated.timing(ringSpin, {
+      Animated.timing(processingSpinNative, {
         toValue: 1,
         duration: 1200,
         useNativeDriver: true,
         easing: Easing.linear,
       })
     );
+
     loop.start();
-    return () => loop.stop();
-  }, [ringSpin, state]);
+    return () => {
+      loop.stop();
+      processingSpinNative.stopAnimation();
+    };
+  }, [state, processingSpinNative]);
 
   useEffect(() => {
     if (state !== "speaking") {
-      speakingShimmer.stopAnimation();
-      speakingShimmer.setValue(0);
+      speakingWaveNative.stopAnimation();
+      speakingWaveNative.setValue(0);
       return;
     }
 
     const loop = Animated.loop(
-      Animated.timing(speakingShimmer, {
+      Animated.timing(speakingWaveNative, {
         toValue: 1,
         duration: 760,
         useNativeDriver: true,
         easing: Easing.inOut(Easing.sin),
       })
     );
-    loop.start();
-    return () => loop.stop();
-  }, [speakingShimmer, state]);
 
-  const orbScale = pressScale.interpolate({
+    loop.start();
+    return () => {
+      loop.stop();
+      speakingWaveNative.stopAnimation();
+    };
+  }, [state, speakingWaveNative]);
+
+  const statusText = useMemo(() => statusTextByState[state], [state]);
+  const ringSize = size + 18;
+
+  const orbPressScale = pressNative.interpolate({
     inputRange: [0, 1],
     outputRange: [1, 1.04],
   });
 
-  const breathingScaleRange = modeTransitionNative.interpolate({
+  const breathingScaleByMode = modeNative.interpolate({
     inputRange: [0, 1, 2],
     outputRange: [1.07, 1.11, 1.05],
   });
-  const ambientScale = Animated.add(
+  const ambientGlowScale = Animated.add(
     1,
-    Animated.multiply(breathing, Animated.subtract(breathingScaleRange, 1))
+    Animated.multiply(breathingNative, Animated.subtract(breathingScaleByMode, 1))
   );
 
-  const motionLift = modeTransitionNative.interpolate({
+  const motionLiftByMode = modeNative.interpolate({
     inputRange: [0, 1, 2],
     outputRange: [1.4, 2.3, 2.8],
   });
 
-  const orbTranslateY = breathing.interpolate({
+  const orbFloat = breathingNative.interpolate({
     inputRange: [0, 1],
     outputRange: [0, -1],
   });
 
-  const primaryGradientColor = modeTransitionColor.interpolate({
-    inputRange: [0, 1, 2],
-    outputRange: ["#FF9A43", "#42E8FF", "#8E63FF"],
-  });
-
-  const secondaryGradientColor = modeTransitionColor.interpolate({
-    inputRange: [0, 1, 2],
-    outputRange: ["#FF6E67", "#2E71FF", "#4A3BBD"],
-  });
-
-  const orbBorderColor = modeTransitionColor.interpolate({
-    inputRange: [0, 1, 2],
-    outputRange: ["#FFD2AC88", "#B0F3FF99", "#D7CBFF88"],
-  });
-
-  const glowColor = modeTransitionColor.interpolate({
-    inputRange: [0, 1, 2],
-    outputRange: ["#FF8A5D", "#42D7FF", "#6C54D6"],
-  });
-
-  const ringAccentColor = modeTransitionColor.interpolate({
-    inputRange: [0, 1, 2],
-    outputRange: ["#FFB27C", "#7AF4FF", "#A58BFF"],
-  });
-
-  const glowOpacityByMode = modeTransitionColor.interpolate({
-    inputRange: [0, 1, 2],
-    outputRange: [0.4, 0.54, 0.28],
-  });
-
-  const glowOpacity = Animated.add(
-    glowOpacityByMode,
-    pressGlowBoost.interpolate({
-      inputRange: [0, 1],
-      outputRange: [0, 0.2],
-    })
-  );
-  const ambientPulseOpacity = Animated.add(
-    breathing.interpolate({
-      inputRange: [0, 1],
-      outputRange: [0.18, 0.32],
-    }),
-    pressScale.interpolate({
-      inputRange: [0, 1],
-      outputRange: [0, 0.1],
-    })
-  );
-
-  const ringScale = ringPulse.interpolate({
+  const listeningRingScale = listeningRingNative.interpolate({
     inputRange: [0, 1],
     outputRange: [1, mode === "bright" ? 1.16 : mode === "warm" ? 1.1 : 1.08],
   });
 
-  const spin = ringSpin.interpolate({
+  const processingSpin = processingSpinNative.interpolate({
     inputRange: [0, 1],
     outputRange: ["0deg", "360deg"],
   });
 
-  const shimmerTranslate = speakingShimmer.interpolate({
+  const speakingWaveTranslate = speakingWaveNative.interpolate({
     inputRange: [0, 0.5, 1],
     outputRange: [0, 1, 0],
   });
 
-  const statusText = useMemo(() => statusTextByState[state], [state]);
-  const ringSize = size + 18;
+  const speakingWaveOpacity = speakingWaveNative.interpolate({
+    inputRange: [0, 0.5, 1],
+    outputRange: [0.35, 1, 0.35],
+  });
+
+  // Color and non-native interpolations live only on modeColor / glowBoostColor
+  const primaryGradientColor = modeColor.interpolate({
+    inputRange: [0, 1, 2],
+    outputRange: ["#FF9A43", "#42E8FF", "#8E63FF"],
+  });
+
+  const secondaryGradientColor = modeColor.interpolate({
+    inputRange: [0, 1, 2],
+    outputRange: ["#FF6E67", "#2E71FF", "#4A3BBD"],
+  });
+
+  const orbBorderColor = modeColor.interpolate({
+    inputRange: [0, 1, 2],
+    outputRange: ["#FFD2AC88", "#B0F3FF99", "#D7CBFF88"],
+  });
+
+  const glowColor = modeColor.interpolate({
+    inputRange: [0, 1, 2],
+    outputRange: ["#FF8A5D", "#42D7FF", "#6C54D6"],
+  });
+
+  const ringAccentColor = modeColor.interpolate({
+    inputRange: [0, 1, 2],
+    outputRange: ["#FFB27C", "#7AF4FF", "#A58BFF"],
+  });
+
+  const ambientGlowOpacityBase = modeColor.interpolate({
+    inputRange: [0, 1, 2],
+    outputRange: [0.4, 0.54, 0.28],
+  });
+
+  const ambientGlowOpacity = Animated.add(
+    ambientGlowOpacityBase,
+    glowBoostColor.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, 0.2],
+    })
+  );
+
+  const ambientPulseOpacity = Animated.add(
+    breathingNative.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0.18, 0.32],
+    }),
+    pressNative.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, 0.1],
+    })
+  );
 
   return (
     <View style={styles.container}>
@@ -298,29 +334,30 @@ const VoiceStage = ({
         style={styles.pressable}
       >
         <View style={[styles.orbShell, { width: size + 20, height: size + 20 }]}>
-        <Animated.View
-          pointerEvents="none"
-          style={{
-            position: "absolute",
-            width: size + 30,
-            height: size + 30,
-            borderRadius: 999,
-            borderWidth: 1,
-            borderColor: "rgba(255,255,255,0.12)",
-            opacity: stateMorph.interpolate({
-              inputRange: [0, 1, 2, 3, 4],
-              outputRange: [0.08, 0.16, 0.2, 0.14, 0.22],
-            }),
-            transform: [
-              {
-                scale: stateMorph.interpolate({
-                  inputRange: [0, 1, 2, 3, 4],
-                  outputRange: [1, 1.03, 1.04, 1.02, 1.05],
-                }),
-              },
-            ],
-          }}
-        />
+          <Animated.View
+            pointerEvents="none"
+            style={{
+              position: "absolute",
+              width: size + 30,
+              height: size + 30,
+              borderRadius: 999,
+              borderWidth: 1,
+              borderColor: "rgba(255,255,255,0.12)",
+              opacity: stateNative.interpolate({
+                inputRange: [0, 1, 2, 3, 4],
+                outputRange: [0.08, 0.16, 0.2, 0.14, 0.22],
+              }),
+              transform: [
+                {
+                  scale: stateNative.interpolate({
+                    inputRange: [0, 1, 2, 3, 4],
+                    outputRange: [1, 1.03, 1.04, 1.02, 1.05],
+                  }),
+                },
+              ],
+            }}
+          />
+
           <Animated.View
             style={[
               styles.ambientGlowBase,
@@ -328,10 +365,12 @@ const VoiceStage = ({
                 width: size + 26,
                 height: size + 26,
                 backgroundColor: glowColor,
-                opacity: glowOpacity,
+                opacity: ambientGlowOpacity,
+                transform: [{ scale: orbPressScale }],
               },
             ]}
           />
+
           <Animated.View
             pointerEvents="none"
             style={[
@@ -340,7 +379,7 @@ const VoiceStage = ({
                 width: size + 34,
                 height: size + 34,
                 opacity: ambientPulseOpacity,
-                transform: [{ scale: ambientScale }],
+                transform: [{ scale: ambientGlowScale }],
               },
             ]}
           />
@@ -353,8 +392,7 @@ const VoiceStage = ({
                   width: ringSize,
                   height: ringSize,
                   borderColor: ringAccentColor,
-                  shadowColor: ringAccentColor,
-                  transform: [{ scale: ringScale }],
+                  transform: [{ scale: listeningRingScale }],
                 },
               ]}
             />
@@ -369,15 +407,15 @@ const VoiceStage = ({
                   height: ringSize,
                   borderTopColor: ringAccentColor,
                   borderRightColor: secondaryGradientColor,
-                  borderBottomColor: modeTransitionColor.interpolate({
+                  borderBottomColor: modeColor.interpolate({
                     inputRange: [0, 1, 2],
                     outputRange: ["#FFB27A22", "#77EEFF22", "#9B84FF22"],
                   }),
-                  borderLeftColor: modeTransitionColor.interpolate({
+                  borderLeftColor: modeColor.interpolate({
                     inputRange: [0, 1, 2],
                     outputRange: ["#FF866422", "#3B78FF22", "#5B49C622"],
                   }),
-                  transform: [{ rotate: spin }],
+                  transform: [{ rotate: processingSpin }],
                 },
               ]}
             />
@@ -392,18 +430,16 @@ const VoiceStage = ({
                     styles.speakingSegment,
                     {
                       backgroundColor: ringAccentColor,
-                      shadowColor: secondaryGradientColor,
                       transform: [
                         { rotate: `${segment * 90}deg` },
-                        { translateY: shimmerTranslate.interpolate({
-                          inputRange: [0, 1],
-                          outputRange: [0, segment % 2 === 0 ? -1.5 : 1.5],
-                        }) },
+                        {
+                          translateY: speakingWaveTranslate.interpolate({
+                            inputRange: [0, 1],
+                            outputRange: [0, segment % 2 === 0 ? -1.5 : 1.5],
+                          }),
+                        },
                       ],
-                      opacity: speakingShimmer.interpolate({
-                        inputRange: [0, 0.5, 1],
-                        outputRange: [0.35, 1, 0.35],
-                      }),
+                      opacity: speakingWaveOpacity,
                     },
                   ]}
                 />
@@ -419,13 +455,13 @@ const VoiceStage = ({
                   width: ringSize - 2,
                   height: ringSize - 2,
                   borderColor: ringAccentColor,
-                  opacity: stateMorph.interpolate({
+                  opacity: stateNative.interpolate({
                     inputRange: [3, 4],
                     outputRange: [0.2, 0.85],
                   }),
                   transform: [
                     {
-                      scale: stateMorph.interpolate({
+                      scale: stateNative.interpolate({
                         inputRange: [3, 4],
                         outputRange: [0.96, 1.02],
                       }),
@@ -444,12 +480,9 @@ const VoiceStage = ({
                 height: size,
                 borderRadius: size / 2,
                 borderColor: orbBorderColor,
-                shadowColor: glowColor,
                 transform: [
-                  { scale: orbScale },
-                  {
-                    translateY: Animated.multiply(orbTranslateY, motionLift),
-                  },
+                  { scale: orbPressScale },
+                  { translateY: Animated.multiply(orbFloat, motionLiftByMode) },
                 ],
               },
             ]}
@@ -470,7 +503,7 @@ const VoiceStage = ({
               style={[
                 styles.orbHighlight,
                 {
-                  opacity: modeTransitionColor.interpolate({
+                  opacity: modeColor.interpolate({
                     inputRange: [0, 1, 2],
                     outputRange: [0.34, 0.28, 0.22],
                   }),
@@ -481,11 +514,11 @@ const VoiceStage = ({
               style={[
                 styles.orbInnerCore,
                 {
-                  backgroundColor: modeTransitionColor.interpolate({
+                  backgroundColor: modeColor.interpolate({
                     inputRange: [0, 1, 2],
                     outputRange: ["#FFF3DF66", "#D7FBFF6B", "#D7CDFF5E"],
                   }),
-                  borderColor: modeTransitionColor.interpolate({
+                  borderColor: modeColor.interpolate({
                     inputRange: [0, 1, 2],
                     outputRange: ["#FFD5B277", "#BBF0FF8A", "#D7C5FF76"],
                   }),
@@ -495,18 +528,19 @@ const VoiceStage = ({
           </Animated.View>
         </View>
       </Pressable>
+
       <Animated.Text
         style={[
           styles.statusText,
           state === "idle" ? styles.statusTextIdle : null,
           {
-            opacity: stateMorph.interpolate({
+            opacity: stateNative.interpolate({
               inputRange: [0, 1, 2, 3, 4],
               outputRange: [0.9, 1, 0.96, 0.94, 1],
             }),
             transform: [
               {
-                translateY: stateMorph.interpolate({
+                translateY: stateNative.interpolate({
                   inputRange: [0, 1, 2, 3, 4],
                   outputRange: [0, -1, -1, 0, -1],
                 }),
@@ -548,8 +582,9 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     overflow: "hidden",
-    shadowOpacity: 0.42,
-    shadowRadius: 18,
+    shadowColor: "#000000",
+    shadowOpacity: 0.34,
+    shadowRadius: 16,
     shadowOffset: { width: 0, height: 8 },
     elevation: 7,
   },
@@ -588,7 +623,8 @@ const styles = StyleSheet.create({
     position: "absolute",
     borderRadius: 999,
     borderWidth: 2,
-    shadowOpacity: 0.4,
+    shadowColor: "#FFFFFF",
+    shadowOpacity: 0.3,
     shadowRadius: 8,
     shadowOffset: { width: 0, height: 0 },
   },
@@ -601,7 +637,8 @@ const styles = StyleSheet.create({
     position: "absolute",
     borderRadius: 999,
     borderWidth: 2,
-    shadowOpacity: 0.35,
+    shadowColor: "#FFFFFF",
+    shadowOpacity: 0.25,
     shadowRadius: 7,
     shadowOffset: { width: 0, height: 0 },
   },
@@ -615,9 +652,6 @@ const styles = StyleSheet.create({
     width: "72%",
     height: 2,
     borderRadius: 999,
-    shadowOpacity: 0.9,
-    shadowRadius: 5,
-    shadowOffset: { width: 0, height: 0 },
   },
   statusText: {
     marginTop: 14,


### PR DESCRIPTION
### Motivation
- Fix two runtime failures: unsupported animated `shadowColor` usage and mixed-driver animated node ownership errors.  
- Ensure no `Animated.Value` is scheduled with both `useNativeDriver: true` and `false`.  
- Preserve the premium orb/look while using only driver-safe animated properties for native performance.

### Description
- Reworked `VoiceStage.tsx` animation architecture to strictly separate native-only and JS-only animated values, introducing `modeNative`/`modeColor` (motion vs color) and dedicated native values like `breathingNative`, `pressNative`, `listeningRingNative`, `processingSpinNative`, and `speakingWaveNative`.  
- Removed all animated shadow properties and stopped passing animated `shadowColor`/`shadowOpacity`/`shadowRadius` into `Animated.View`; glow is implemented via layered views that animate `opacity` and `transform` only.  
- Replaced mixed `Animated.parallel` orchestration of native + JS transitions with separate `useEffect` timelines so each `Animated.Value` is always driven with a single driver.  
- Improved lifecycle and loop handling so state-specific loops start/stop/reset cleanly when `state` or `mode` change and unrelated animated nodes are not restarted.

### Testing
- Type-checking: ran `cd mobile && npx tsc --noEmit` and it completed successfully (with a non-fatal npm env warning).  
- Verified there are no remaining references to animated `shadowColor`/`shadowOpacity`/`shadowRadius`, and that native-only values are never used with `useNativeDriver: false`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c49ab3d0f48333a1121e49da290513)