### PR TITLE
Add Chinese language support with UI localization

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -618,7 +618,7 @@ async def llm_chat(
     system_prompt = _build_system_prompt(request.speaker)
     payload = {
         "systemInstruction": {"parts": [{"text": system_prompt}]},
-        "generationConfig": {"maxOutputTokens": 160},
+        "generationConfig": {"maxOutputTokens": 300},
         "contents": [
             {
                 "role": "model" if message.role == "assistant" else "user",
@@ -693,9 +693,9 @@ async def llm_chat(
                 logger.info("Repair Gemini call completed")
                 logger.info("Repaired Gemini response preview: %s", repaired[:300])
                 content = repaired if _is_structured_beginner_reply(repaired) else (
-                    "Chinese: 抱歉，我刚才格式化失败了。请再试一次，我会直接帮你翻译这句英文。\n"
-                    "Pinyin: Bàoqiàn, wǒ gāngcái géshìhuà shībài le. Qǐng zài shì yí cì, wǒ huì zhíjiē bāng nǐ fānyì zhè jù Yīngwén.\n"
-                    "Meaning: Sorry, formatting failed just now. Please try once more and I will translate your English sentence directly."
+                    "Chinese: 请再试一次\n"
+                    "Pinyin: Qǐng zài shì yī cì\n"
+                    "Meaning: Something went wrong. Please try your question again."
                 )
     except httpx.HTTPStatusError as exc:
         body_preview = exc.response.text[:1000] if exc.response is not None else ""

--- a/backend/app/services/gemini_stt.py
+++ b/backend/app/services/gemini_stt.py
@@ -12,7 +12,10 @@ class GeminiSTTClient:
         self._model = model
         self._client = httpx.AsyncClient(timeout=30.0)  # reuse connections
 
-    def _needs_normalization(self, t: str) -> bool:
+    def _needs_normalization(self, t: str, source_lang: str = "en") -> bool:
+        # Chinese transcription has different error patterns — skip English-specific normalization
+        if source_lang == "zh":
+            return False
         s = (t or "").strip()
         if len(s.split()) <= 2:
             return True
@@ -24,15 +27,24 @@ class GeminiSTTClient:
     async def transcribe_raw(self, audio_bytes: bytes, mime_type: str, source_lang: str) -> str:
         encoded = base64.b64encode(audio_bytes).decode("utf-8")
 
+        if source_lang == "zh":
+            system_text = (
+                "You are a speech transcription engine for a Chinese language learning app. "
+                "Transcribe the user's spoken Chinese as natural Simplified Chinese characters. "
+                "Return ONLY the transcript text."
+            )
+        else:
+            system_text = (
+                "You are a speech transcription engine for an English learning app. "
+                "Transcribe the user's spoken request as natural English. "
+                "Return ONLY the transcript text."
+            )
+
         payload = {
             "systemInstruction": {
                 "parts": [
                     {
-                        "text": (
-                            "You are a speech transcription engine for an English learning app. "
-                            "Transcribe the user's spoken request as natural English. "
-                            "Return ONLY the transcript text."
-                        )
+                        "text": system_text
                     }
                 ]
             },
@@ -124,7 +136,7 @@ class GeminiSTTClient:
     # --- STEP 3: public API (what the rest of your app already uses) ---
     async def transcribe(self, audio_bytes: bytes, mime_type: str, source_lang: str) -> str:
         raw = await self.transcribe_raw(audio_bytes, mime_type, source_lang)
-        if self._needs_normalization(raw):
+        if self._needs_normalization(raw, source_lang):
             norm = await self.normalize_transcript(raw)
             return norm
         return raw

--- a/backend/app/services/speech_turn.py
+++ b/backend/app/services/speech_turn.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -104,7 +105,7 @@ class GeminiSpeechTurnTextClient:
             if response.status_code == 429:
                 wait = 0.5 * (2**attempt)
                 logger.warning("TEXT 429 Too Many Requests. retrying in %.1fs", wait)
-                time.sleep(wait)
+                await asyncio.sleep(wait)
                 continue
 
             try:

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -569,6 +569,13 @@ export default function App() {
     await AsyncStorage.setItem(STORAGE_KEY, selection);
   };
 
+  const handleSwitchLanguage = async (next: SpeakerPreference) => {
+    if (next === preference) return;
+    setMessages([]);
+    setPreference(next);
+    await AsyncStorage.setItem(STORAGE_KEY, next);
+  };
+
   const handleLogin = async (username: string, password: string) => {
     if (!username || !password) {
       setAuthError("Enter both username and password.");
@@ -1340,11 +1347,27 @@ export default function App() {
             >
               Chinese Tutor
             </Animated.Text>
-            {DEMO_MODE || CHATBOT_ONLY_MODE || !REQUIRE_AUTH ? null : (
-              <Pressable onPress={handleLogout}>
-                <Text style={styles.logoutText}>Logout</Text>
-              </Pressable>
-            )}
+            <View style={styles.headerRight}>
+              <View style={styles.langToggle}>
+                <Pressable
+                  style={[styles.langPill, preference === "english" && styles.langPillActive]}
+                  onPress={() => void handleSwitchLanguage("english")}
+                >
+                  <Text style={[styles.langPillText, preference === "english" && styles.langPillTextActive]}>EN</Text>
+                </Pressable>
+                <Pressable
+                  style={[styles.langPill, preference === "chinese" && styles.langPillActive]}
+                  onPress={() => void handleSwitchLanguage("chinese")}
+                >
+                  <Text style={[styles.langPillText, preference === "chinese" && styles.langPillTextActive]}>中</Text>
+                </Pressable>
+              </View>
+              {DEMO_MODE || CHATBOT_ONLY_MODE || !REQUIRE_AUTH ? null : (
+                <Pressable onPress={handleLogout}>
+                  <Text style={styles.logoutText}>Logout</Text>
+                </Pressable>
+              )}
+            </View>
           </View>
           <Animated.Text
             style={[styles.subtitle, { color: interpolatedTheme.subtitleText }]}
@@ -1727,6 +1750,35 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: "#B91C1C",
     fontWeight: "600",
+  },
+  headerRight: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  langToggle: {
+    flexDirection: "row",
+    gap: 4,
+  },
+  langPill: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: "rgba(107, 44, 18, 0.25)",
+    backgroundColor: "rgba(255,255,255,0.15)",
+  },
+  langPillActive: {
+    backgroundColor: "rgba(107, 44, 18, 0.12)",
+    borderColor: "rgba(107, 44, 18, 0.5)",
+  },
+  langPillText: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: "rgba(107, 44, 18, 0.4)",
+  },
+  langPillTextActive: {
+    color: "#6B2C12",
   },
   messagesContent: {
     flexGrow: 1,

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -771,7 +771,11 @@ export default function App() {
 
       streamAssistantResponse(assistantId, data.reply);
     } catch (error) {
-      setError("抱歉，暂时无法连接到服务器。请稍后再试。");
+      setError(
+        preference === "chinese"
+          ? "抱歉，暂时无法连接到服务器。请稍后再试。"
+          : "Could not reach the server. Please try again."
+      );
       setMessages((prev) =>
         prev.filter((message) => !message.isTyping)
       );

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -180,12 +180,20 @@ const LoadingState = ({
   </SafeAreaView>
 );
 
-const EmptyChatState = () => (
+const EmptyChatState = ({ preference }: { preference: SpeakerPreference }) => (
   <View style={styles.emptyStateCard}>
-    <Text style={styles.emptyStateEyebrow}>Start learning</Text>
-    <Text style={styles.emptyStateTitle}>Say one phrase out loud or type one.</Text>
+    <Text style={styles.emptyStateEyebrow}>
+      {preference === “chinese” ? “开始学习” : “Start learning”}
+    </Text>
+    <Text style={styles.emptyStateTitle}>
+      {preference === “chinese”
+        ? “说一句中文，或者打一句话。”
+        : “Say one phrase out loud or type one.”}
+    </Text>
     <Text style={styles.emptyStateBody}>
-      Try: “How do I say nice to meet you?” or “1, 2, 3 in Chinese.”
+      {preference === “chinese”
+        ? “试试：”你好是什么意思？”或”1、2、3用英文怎么说？””
+        : “Try: \”How do I say nice to meet you?\” or \”1, 2, 3 in Chinese.\””}
     </Text>
   </View>
 );
@@ -1381,7 +1389,9 @@ export default function App() {
           <Animated.Text
             style={[styles.voiceSubtitle, { color: interpolatedTheme.voiceSupportText }]}
           >
-            Hold the button, speak, and release to translate + hear it back.
+            {preference === "chinese"
+              ? "按住按钮，说一句中文，松开后听英文翻译。"
+              : "Hold the button, speak, and release to translate + hear it back."}
           </Animated.Text>
           {micPermission === "denied" ? (
             <Text style={styles.voiceError}>
@@ -1488,7 +1498,7 @@ export default function App() {
           keyExtractor={(item) => item.id}
           renderItem={renderItem}
           contentContainerStyle={styles.messagesContent}
-          ListEmptyComponent={<EmptyChatState />}
+          ListEmptyComponent={<EmptyChatState preference={preference} />}
           onContentSizeChange={() =>
             listRef.current?.scrollToEnd({ animated: true })
           }

--- a/mobile/src/components/StructuredLearningCard.tsx
+++ b/mobile/src/components/StructuredLearningCard.tsx
@@ -23,7 +23,7 @@ export const parseLearningCard = (text: string) => {
   const taggedEnglish = normalized.find(
     (line) => /^(english|meaning|translation)\s*:/i.test(line)
   );
-  const taggedTip = normalized.find((line) => /^(tip|example|note)\s*:/i.test(line));
+  const taggedTip = normalized.find((line) => /^(tip|example|notes?)\s*:/i.test(line));
 
   const chineseFromTag = taggedChinese?.replace(/^chinese\s*:/i, "").trim();
   const pinyinFromTag = taggedPinyin?.replace(/^pinyin\s*:/i, "").trim();


### PR DESCRIPTION
## Summary
This PR adds comprehensive Chinese language support to the app, including UI localization, language switching functionality, and improved speech transcription handling for Chinese input.

## Key Changes

### Mobile App (App.tsx)
- **Language Toggle UI**: Added a language preference switcher in the header with "EN" and "中" pill buttons that allow users to toggle between English and Chinese
- **UI Localization**: Translated empty chat state messages (eyebrow, title, and body text) to display in Chinese when preference is set to "chinese"
- **Voice Instructions**: Localized the voice recording instruction text to Chinese
- **Language Switching Handler**: Implemented `handleSwitchLanguage()` function that clears chat history and persists language preference to AsyncStorage
- **Component Updates**: Updated `EmptyChatState` component to accept and use the `preference` prop for conditional rendering

### Backend Speech Transcription (gemini_stt.py)
- **Language-Aware Normalization**: Modified `_needs_normalization()` to skip English-specific normalization rules when transcribing Chinese (`source_lang == "zh"`)
- **Dual System Prompts**: Updated `transcribe_raw()` to use language-specific system instructions for Gemini API, with separate prompts optimized for Chinese vs English transcription
- **Transcription Flow**: Updated the public `transcribe()` method to pass `source_lang` to the normalization check

### Backend Chat & Error Handling (main.py)
- **Token Limit Increase**: Increased `maxOutputTokens` from 160 to 300 to allow more detailed responses
- **Simplified Error Message**: Replaced verbose error recovery message with a concise Chinese/English fallback message

### Backend Async Fix (speech_turn.py)
- **Async Sleep**: Changed `time.sleep()` to `await asyncio.sleep()` in the retry logic to prevent blocking the async event loop during rate limit backoff

### Learning Card Parser (StructuredLearningCard.tsx)
- **Regex Enhancement**: Updated tip/note tag regex pattern from `/^(tip|example|note)\s*:/i` to `/^(tip|example|notes?)\s*:/i` to handle both singular and plural "note/notes" variants

## Implementation Details
- Language preference is persisted across app sessions using AsyncStorage
- Switching languages clears the message history to provide a fresh start
- Chinese transcription uses simplified Chinese characters (Simplified Chinese) as specified in the system prompt
- The language toggle is positioned in the header alongside the logout button with a clean pill-button design

https://claude.ai/code/session_01FbP6hANivppjJMS6ZYyhDN