### PR TITLE
Enhance voice option styling with color customization

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1504,29 +1504,35 @@ export default function App() {
           ) : null}
           <View style={styles.voiceOptionsRow}>
             {[
-              { key: "warm", label: "Warm" },
-              { key: "bright", label: "Bright" },
-              { key: "deep", label: "Deep" },
-            ].map((option) => (
-              <Pressable
-                key={option.key}
-                style={[
-                  styles.voiceOptionPill,
-                  selectedVoice === option.key && styles.voiceOptionPillActive,
-                ]}
-                onPress={() => setSelectedVoice(option.key as VoiceOption)}
-                disabled={isRecording || isUploadingVoice}
-              >
-                <Text
+              { key: "warm", label: "Warm", inactiveBg: "#FED7AA", inactiveBorder: "#FDBA74", inactiveText: "#9A3412", activeBg: "#C2410C", activeBorder: "#9A3412" },
+              { key: "bright", label: "Bright", inactiveBg: "#BAE6FD", inactiveBorder: "#7DD3FC", inactiveText: "#0C4A6E", activeBg: "#0369A1", activeBorder: "#075985" },
+              { key: "deep", label: "Deep", inactiveBg: "#DDD6FE", inactiveBorder: "#C4B5FD", inactiveText: "#4C1D95", activeBg: "#5B21B6", activeBorder: "#4C1D95" },
+            ].map((option) => {
+              const isActive = selectedVoice === option.key;
+              return (
+                <Pressable
+                  key={option.key}
                   style={[
-                    styles.voiceOptionText,
-                    selectedVoice === option.key && styles.voiceOptionTextActive,
+                    styles.voiceOptionPill,
+                    {
+                      backgroundColor: isActive ? option.activeBg : option.inactiveBg,
+                      borderColor: isActive ? option.activeBorder : option.inactiveBorder,
+                    },
                   ]}
+                  onPress={() => setSelectedVoice(option.key as VoiceOption)}
+                  disabled={isRecording || isUploadingVoice}
                 >
-                  {option.label}
-                </Text>
-              </Pressable>
-            ))}
+                  <Text
+                    style={[
+                      styles.voiceOptionText,
+                      { color: isActive ? "#FFFFFF" : option.inactiveText },
+                    ]}
+                  >
+                    {option.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
           </View>
 
           <Animated.View

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -656,7 +656,7 @@ export default function App() {
       return "Hi! I’m your Chinese tutor. Say hello or tell me what you want to practice.";
     }
     if (preference === "chinese") {
-      return "Hello! I'm your Chinese tutor. Say hello, or tell me what you'd like to practice.";
+      return "Chinese: Hello! I’m your English tutor.\nEnglish: 你好！我是你的英语导师，告诉我你想练什么吧。";
     }
     return "";
   }, [preference]);


### PR DESCRIPTION
## Summary
Updated the voice option selection UI to use custom color schemes for each voice type (Warm, Bright, Deep) with distinct inactive and active states, and improved the Chinese tutor greeting message.

## Key Changes
- **Voice Option Styling**: Replaced generic stylesheet-based styling with inline color customization for each voice option
  - Added color properties to voice option objects: `inactiveBg`, `inactiveBorder`, `inactiveText`, `activeBg`, `activeBorder`
  - Warm voice: Orange tones (#FED7AA → #C2410C)
  - Bright voice: Blue tones (#BAE6FD → #0369A1)
  - Deep voice: Purple tones (#DDD6FE → #5B21B6)
  - Dynamic text color that switches to white when active

- **Chinese Tutor Greeting**: Updated the greeting message for Chinese preference to include bilingual content with both Chinese and English versions

## Implementation Details
- Refactored the voice options map to compute `isActive` state within the render function for cleaner conditional styling
- Inline styles now directly reference the color properties from each option object, eliminating the need for separate CSS classes for different voice types
- Maintains the same disabled state behavior during recording or voice upload

https://claude.ai/code/session_01XErmqEJt4X8WzJCLhiyo8b