### PR TITLE
Apply theme colors to language toggle and mic button

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1428,16 +1428,26 @@ export default function App() {
             <View style={styles.headerRight}>
               <View style={styles.langToggle}>
                 <Pressable
-                  style={[styles.langPill, preference === "english" && styles.langPillActive]}
+                  style={[
+                    styles.langPill,
+                    { borderColor: interpolatedTheme.surfaceBorder },
+                    preference === "english" && styles.langPillActive,
+                    preference === "english" && { borderColor: interpolatedTheme.messageAccentText },
+                  ]}
                   onPress={() => void handleSwitchLanguage("english")}
                 >
-                  <Text style={[styles.langPillText, preference === "english" && styles.langPillTextActive]}>EN</Text>
+                  <Text style={[styles.langPillText, { color: interpolatedTheme.subtitleText }, preference === "english" && styles.langPillTextActive, preference === "english" && { color: interpolatedTheme.titleText }]}>EN</Text>
                 </Pressable>
                 <Pressable
-                  style={[styles.langPill, preference === "chinese" && styles.langPillActive]}
+                  style={[
+                    styles.langPill,
+                    { borderColor: interpolatedTheme.surfaceBorder },
+                    preference === "chinese" && styles.langPillActive,
+                    preference === "chinese" && { borderColor: interpolatedTheme.messageAccentText },
+                  ]}
                   onPress={() => void handleSwitchLanguage("chinese")}
                 >
-                  <Text style={[styles.langPillText, preference === "chinese" && styles.langPillTextActive]}>中</Text>
+                  <Text style={[styles.langPillText, { color: interpolatedTheme.subtitleText }, preference === "chinese" && styles.langPillTextActive, preference === "chinese" && { color: interpolatedTheme.titleText }]}>中</Text>
                 </Pressable>
               </View>
               {DEMO_MODE || CHATBOT_ONLY_MODE || !REQUIRE_AUTH ? null : (
@@ -1664,7 +1674,8 @@ export default function App() {
             <Pressable
               style={[
                 styles.micButton,
-                isRecording && styles.micButtonActive,
+                { backgroundColor: activeTheme.sendButtonBackground },
+                isRecording && { backgroundColor: activeTheme.sendButtonBorder },
                 (isUploadingVoice || micPermission === "denied") &&
                   styles.micButtonDisabled,
               ]}


### PR DESCRIPTION
## Summary
Updated the language toggle pills and microphone button to use dynamic theme colors instead of static styles, ensuring consistent theming across the app.

## Key Changes
- **Language Toggle Pills**: Applied `interpolatedTheme` colors to both the English and Chinese language selector buttons
  - Border color now uses `surfaceBorder` for inactive state and `messageAccentText` for active state
  - Text color now uses `subtitleText` for inactive state and `titleText` for active state
  
- **Microphone Button**: Replaced static style references with dynamic theme colors
  - Background color now uses `activeTheme.sendButtonBackground` for default state
  - Background color uses `activeTheme.sendButtonBorder` when recording is active

## Implementation Details
The changes maintain the existing conditional logic for active/inactive states while layering theme-aware color overrides on top of the base styles. This approach ensures the UI respects the current theme preference while preserving the original component behavior.

https://claude.ai/code/session_01DQZycGbrm2uE2LRfwdixnf