### PR TITLE
fix: memoize Animated interpolations to prevent render error

### DIFF
--- a/mobile/src/components/StructuredLearningCard.tsx
+++ b/mobile/src/components/StructuredLearningCard.tsx
@@ -157,6 +157,7 @@ const SingleCard = ({
   delay = 0,
 }: CardData & { mode?: "english" | "chinese"; delay?: number }) => {
   const entrance = useRef(new Animated.Value(0)).current;
+  const entranceTranslateY = useRef(entrance.interpolate({ inputRange: [0, 1], outputRange: [12, 0] })).current;
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -172,16 +173,9 @@ const SingleCard = ({
   const cardStyle = useMemo(
     () => ({
       opacity: entrance,
-      transform: [
-        {
-          translateY: entrance.interpolate({
-            inputRange: [0, 1],
-            outputRange: [12, 0],
-          }),
-        },
-      ],
+      transform: [{ translateY: entranceTranslateY }],
     }),
-    [entrance]
+    [entrance, entranceTranslateY]
   );
 
   const isZh = mode === "chinese";

--- a/mobile/src/components/VoiceStage.tsx
+++ b/mobile/src/components/VoiceStage.tsx
@@ -67,6 +67,7 @@ const VoiceStage = ({
   const STATE_LABEL = preference === "chinese" ? STATE_LABEL_ZH : STATE_LABEL_EN;
   const pressAnim  = useRef(new Animated.Value(0)).current;
   const pulseAnim  = useRef(new Animated.Value(1)).current;
+  const scale = useRef(pressAnim.interpolate({ inputRange: [0, 1], outputRange: [1, 0.96] })).current;
 
   const isListening  = state === "listening";
   const isProcessing = state === "processing";
@@ -111,7 +112,6 @@ const VoiceStage = ({
   }, [isProcessing, pulseAnim]);
 
   const { bg, bgPress, border } = MODE_COLORS[mode];
-  const scale = pressAnim.interpolate({ inputRange: [0, 1], outputRange: [1, 0.96] });
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
## Summary

- All `.interpolate()` calls across `App.tsx`, `VoiceStage.tsx`, and `StructuredLearningCard.tsx` were being executed inline during render, creating new `AnimatedInterpolation` child nodes on every re-render
- When React Native's native driver freezes the internal animated node state, the subsequent `_children.push()` call fails with **"cannot add a new property"** (Render Error)
- Moved all interpolations into `useRef(...).current` so each interpolation node is created once per component instance and reused across renders

## Files changed

- `mobile/App.tsx` — fixed `useMicroButton` hook, `TypingIndicator`, `MessageBubble`, and 11 inline interpolations in the main `App` component
- `mobile/src/components/VoiceStage.tsx` — fixed `pressAnim.interpolate()` called inline in component body
- `mobile/src/components/StructuredLearningCard.tsx` — fixed `entrance.interpolate()` inside `useMemo`

## Test plan

- [ ] Launch the app on iOS and verify no "Render Error: cannot add a new property" appears
- [ ] Confirm all animations work correctly (ambient blobs, header entrance, voice stage transitions, input focus, send burst, button press feedback)
- [ ] Switch between voice modes and confirm theme color transitions animate smoothly
- [ ] Send a message and verify the send burst animation plays

https://claude.ai/code/session_01KbbsAQGGdVWrMy1YLVrxVD