### PR TITLE
Fix React 19 frozen object issues with Animated nodes

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -210,6 +210,12 @@ const MessageBubble = ({
 }) => {
   const entrance = useRef(new Animated.Value(0)).current;
   const entranceTranslateY = useRef(entrance.interpolate({ inputRange: [0, 1], outputRange: [10, 0] })).current;
+  // Keep animated style in a stable ref so Animated.View doesn't detach/reattach
+  // child tracking on every render (which can corrupt frozen _children arrays).
+  const animatedStyle = useRef({
+    opacity: entrance,
+    transform: [{ translateY: entranceTranslateY }],
+  }).current;
 
   useEffect(() => {
     Animated.timing(entrance, {
@@ -231,10 +237,7 @@ const MessageBubble = ({
               borderColor: theme.userMessageBorder,
             }
           : null,
-        {
-          opacity: entrance,
-          transform: [{ translateY: entranceTranslateY }],
-        },
+        animatedStyle,
       ]}
     >
       {item.isTyping ? (
@@ -670,7 +673,17 @@ export default function App() {
     return "";
   }, [preference]);
 
-  const interpolatedTheme = useMemo(() => {
+  // Use useRef-based caching instead of useMemo for the interpolated theme.
+  // Animated.Interpolation nodes are mutable (they track _children internally);
+  // storing them in useMemo risks React 19 freezing their internal arrays in DEV,
+  // which causes "cannot add a new property" when Animated.View tries to attach.
+  const interpolatedThemeCache = useRef<{
+    key: string;
+    theme: { [K in keyof ModeTheme]: Animated.AnimatedInterpolation<string> };
+  } | null>(null);
+
+  const themeKey = `${themeFrom}|${themeTo}`;
+  if (!interpolatedThemeCache.current || interpolatedThemeCache.current.key !== themeKey) {
     const fromTheme = MODE_THEMES[themeFrom];
     const toTheme = MODE_THEMES[themeTo];
     const interpolateColor = (key: keyof ModeTheme) =>
@@ -679,36 +692,41 @@ export default function App() {
         outputRange: [fromTheme[key], toTheme[key]],
       });
 
-    return {
-      gradientTop: interpolateColor("gradientTop"),
-      gradientBottom: interpolateColor("gradientBottom"),
-      blobPrimary: interpolateColor("blobPrimary"),
-      blobSecondary: interpolateColor("blobSecondary"),
-      headerSurface: interpolateColor("headerSurface"),
-      headerGlow: interpolateColor("headerGlow"),
-      headerAccentTrack: interpolateColor("headerAccentTrack"),
-      headerAccentLine: interpolateColor("headerAccentLine"),
-      surfaceTint: interpolateColor("surfaceTint"),
-      surfaceBorder: interpolateColor("surfaceBorder"),
-      titleText: interpolateColor("titleText"),
-      subtitleText: interpolateColor("subtitleText"),
-      voiceLabelText: interpolateColor("voiceLabelText"),
-      voiceSupportText: interpolateColor("voiceSupportText"),
-      inputBarBackground: interpolateColor("inputBarBackground"),
-      inputBarBorder: interpolateColor("inputBarBorder"),
-      composerBackground: interpolateColor("composerBackground"),
-      composerBorder: interpolateColor("composerBorder"),
-      inputText: interpolateColor("inputText"),
-      inputPlaceholder: interpolateColor("inputPlaceholder"),
-      sendButtonBackground: interpolateColor("sendButtonBackground"),
-      sendButtonBorder: interpolateColor("sendButtonBorder"),
-      sendButtonText: interpolateColor("sendButtonText"),
-      userMessageBackground: interpolateColor("userMessageBackground"),
-      userMessageBorder: interpolateColor("userMessageBorder"),
-      userMessageText: interpolateColor("userMessageText"),
-      messageAccentText: interpolateColor("messageAccentText"),
+    interpolatedThemeCache.current = {
+      key: themeKey,
+      theme: {
+        gradientTop: interpolateColor("gradientTop"),
+        gradientBottom: interpolateColor("gradientBottom"),
+        blobPrimary: interpolateColor("blobPrimary"),
+        blobSecondary: interpolateColor("blobSecondary"),
+        headerSurface: interpolateColor("headerSurface"),
+        headerGlow: interpolateColor("headerGlow"),
+        headerAccentTrack: interpolateColor("headerAccentTrack"),
+        headerAccentLine: interpolateColor("headerAccentLine"),
+        surfaceTint: interpolateColor("surfaceTint"),
+        surfaceBorder: interpolateColor("surfaceBorder"),
+        titleText: interpolateColor("titleText"),
+        subtitleText: interpolateColor("subtitleText"),
+        voiceLabelText: interpolateColor("voiceLabelText"),
+        voiceSupportText: interpolateColor("voiceSupportText"),
+        inputBarBackground: interpolateColor("inputBarBackground"),
+        inputBarBorder: interpolateColor("inputBarBorder"),
+        composerBackground: interpolateColor("composerBackground"),
+        composerBorder: interpolateColor("composerBorder"),
+        inputText: interpolateColor("inputText"),
+        inputPlaceholder: interpolateColor("inputPlaceholder"),
+        sendButtonBackground: interpolateColor("sendButtonBackground"),
+        sendButtonBorder: interpolateColor("sendButtonBorder"),
+        sendButtonText: interpolateColor("sendButtonText"),
+        userMessageBackground: interpolateColor("userMessageBackground"),
+        userMessageBorder: interpolateColor("userMessageBorder"),
+        userMessageText: interpolateColor("userMessageText"),
+        messageAccentText: interpolateColor("messageAccentText"),
+      },
     };
-  }, [themeColorProgress, themeFrom, themeTo]);
+  }
+
+  const interpolatedTheme = interpolatedThemeCache.current.theme;
   const activeTheme = MODE_THEMES[selectedVoice];
 
   useEffect(() => {
@@ -1269,13 +1287,24 @@ export default function App() {
     [preference, messages, isSending]
   );
 
-  const renderItem = ({ item }: { item: ChatMessage }) => (
-    <MessageBubble
-      item={item}
-      theme={activeTheme}
-      preference={preference}
-      onSuggestionPress={handleSuggestionPress}
-    />
+  // Shallow-copy each message so FlatList items are plain, unfrozen objects.
+  // React 19 deep-freezes useState values in DEV; passing frozen objects into
+  // Animated-backed list cells can trigger "cannot add a new property".
+  const flatListData = useMemo(
+    () => messages.map((m) => ({ ...m })),
+    [messages]
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: ChatMessage }) => (
+      <MessageBubble
+        item={item}
+        theme={activeTheme}
+        preference={preference}
+        onSuggestionPress={handleSuggestionPress}
+      />
+    ),
+    [activeTheme, preference, handleSuggestionPress]
   );
 
   if (isLoadingAppLock) {
@@ -1591,7 +1620,7 @@ export default function App() {
 
         <FlatList
           ref={listRef}
-          data={messages}
+          data={flatListData}
           keyExtractor={(item) => item.id}
           renderItem={renderItem}
           contentContainerStyle={styles.messagesContent}

--- a/mobile/src/components/StructuredLearningCard.tsx
+++ b/mobile/src/components/StructuredLearningCard.tsx
@@ -1,5 +1,5 @@
 import { Animated, Pressable, StyleSheet, Text, View } from "react-native";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 
 type CardData = {
   chinese: string;
@@ -170,13 +170,12 @@ const SingleCard = ({
     return () => clearTimeout(timer);
   }, [entrance, delay]);
 
-  const cardStyle = useMemo(
-    () => ({
-      opacity: entrance,
-      transform: [{ translateY: entranceTranslateY }],
-    }),
-    [entrance, entranceTranslateY]
-  );
+  // Store animated style in useRef instead of useMemo to prevent React 19
+  // from freezing the Animated nodes' internal _children arrays.
+  const cardStyle = useRef({
+    opacity: entrance,
+    transform: [{ translateY: entranceTranslateY }],
+  }).current;
 
   const isZh = mode === "chinese";
   const primaryLabel = isZh ? "ENGLISH" : "CHINESE";


### PR DESCRIPTION
## Summary
This PR addresses compatibility issues with React 19's object freezing behavior in development mode, which was causing "cannot add a new property" errors when Animated nodes tried to track child components internally.

## Key Changes

- **MessageBubble component**: Moved animated style object from inline definition to a stable `useRef` to prevent Animated.View from detaching/reattaching child tracking on every render, which could corrupt frozen `_children` arrays.

- **App component theme interpolation**: Replaced `useMemo`-based caching with `useRef`-based caching for interpolated theme values. Since `Animated.Interpolation` nodes are mutable and track `_children` internally, storing them in `useMemo` risks React 19 freezing their internal arrays in development mode.

- **FlatList data handling**: 
  - Added shallow-copy of messages via `useMemo` to ensure FlatList items are plain, unfrozen objects rather than frozen useState values
  - Wrapped `renderItem` in `useCallback` to maintain stable reference and prevent unnecessary re-renders

- **StructuredLearningCard component**: Replaced `useMemo` with `useRef` for the card animated style object to prevent React 19 from freezing the Animated nodes' internal `_children` arrays.

## Implementation Details

The core issue is that React 19 deep-freezes state values in development mode for safety. When these frozen objects are passed to Animated-backed components, the Animated library's internal mutation of `_children` tracking arrays fails. The solution uses `useRef` for mutable Animated objects (which don't need to trigger re-renders on creation) while keeping `useMemo` for derived data that needs dependency tracking.

https://claude.ai/code/session_01GkfQ5rCiZf81kXp4517oPf