### PR TITLE
Fix Gemini API response parsing to skip thinking tokens

### DIFF
--- a/backend/app/services/gemini_stt.py
+++ b/backend/app/services/gemini_stt.py
@@ -73,11 +73,14 @@ class GeminiSTTClient:
         response.raise_for_status()
         data = response.json()
 
-        transcript = (
+        parts = (
             data.get("candidates", [{}])[0]
             .get("content", {})
-            .get("parts", [{}])[0]
-            .get("text")
+            .get("parts", [{}])
+        )
+        transcript = next(
+            (p.get("text") for p in parts if not p.get("thought") and p.get("text")),
+            None,
         )
 
         if not transcript:
@@ -121,12 +124,14 @@ class GeminiSTTClient:
         response.raise_for_status()
         data = response.json()
 
-        cleaned = (
+        parts = (
             data.get("candidates", [{}])[0]
             .get("content", {})
-            .get("parts", [{}])[0]
-            .get("text", "")
-            .strip()
+            .get("parts", [{}])
+        )
+        cleaned = next(
+            (p.get("text", "").strip() for p in parts if not p.get("thought") and p.get("text")),
+            "",
         )
 
         # Fallback safely if model returns nothing

--- a/backend/app/services/speech_turn.py
+++ b/backend/app/services/speech_turn.py
@@ -84,7 +84,7 @@ class GeminiSpeechTurnTextClient:
         payload = {
             "generationConfig": {
                 "temperature": 0.2,
-                "maxOutputTokens": 256,
+                "maxOutputTokens": 512,
                 "responseMimeType": "application/json",
                 "responseSchema": response_schema,
             },
@@ -115,11 +115,16 @@ class GeminiSpeechTurnTextClient:
                 break
 
             data = response.json()
-            content = (
+            parts = (
                 data.get("candidates", [{}])[0]
                 .get("content", {})
-                .get("parts", [{}])[0]
-                .get("text")
+                .get("parts", [{}])
+            )
+            # Gemini 2.5+ may include thinking tokens (thought=True) before the
+            # actual response part.  Skip those and grab the first real text part.
+            content = next(
+                (p.get("text") for p in parts if not p.get("thought") and p.get("text")),
+                None,
             )
             if not content:
                 raise ValueError("Gemini text generation returned no content.")

--- a/backend/tests/test_gemini_parsing.py
+++ b/backend/tests/test_gemini_parsing.py
@@ -1,0 +1,158 @@
+"""Unit tests for Gemini response parsing — no JWT or HTTP required."""
+import json
+
+import pytest
+
+from app.services.speech_turn import _parse_text_result, _build_response_parts
+
+
+# ---------------------------------------------------------------------------
+# Helpers that simulate the Gemini API response structure
+# ---------------------------------------------------------------------------
+
+def _gemini_response(parts: list[dict]) -> dict:
+    """Wrap parts in a minimal Gemini generateContent response envelope."""
+    return {"candidates": [{"content": {"parts": parts}}]}
+
+
+def _extract_content(data: dict) -> str | None:
+    """Mirrors the fixed extraction logic in speech_turn.py."""
+    parts = (
+        data.get("candidates", [{}])[0]
+        .get("content", {})
+        .get("parts", [{}])
+    )
+    return next(
+        (p.get("text") for p in parts if not p.get("thought") and p.get("text")),
+        None,
+    )
+
+
+VALID_JSON = json.dumps({
+    "normalized_request": "How do I say: 'I want to ask a girl out on a date'?",
+    "intent": "translate_request",
+    "target_text": "我想约你出去约会",
+    "romanization": "wǒ xiǎng yuē nǐ chūqù yuēhuì",
+    "chinese": "我想约你出去约会",
+    "pinyin": "wǒ xiǎng yuē nǐ chūqù yuēhuì",
+    "notes": ["Romantic phrasing; tone 3 on 想 (xiǎng)"],
+})
+
+
+# ---------------------------------------------------------------------------
+# Part extraction — the core of the thinking-token fix
+# ---------------------------------------------------------------------------
+
+class TestGeminiPartExtraction:
+    def test_plain_response_returns_text(self):
+        data = _gemini_response([{"text": VALID_JSON}])
+        assert _extract_content(data) == VALID_JSON
+
+    def test_thinking_token_first_skipped(self):
+        """Gemini 2.5-flash prepends a thought part; extraction must skip it."""
+        data = _gemini_response([
+            {"thought": True, "text": "Let me think about this translation..."},
+            {"text": VALID_JSON},
+        ])
+        assert _extract_content(data) == VALID_JSON
+
+    def test_multiple_thinking_tokens_skipped(self):
+        data = _gemini_response([
+            {"thought": True, "text": "First thought"},
+            {"thought": True, "text": "Second thought"},
+            {"text": VALID_JSON},
+        ])
+        assert _extract_content(data) == VALID_JSON
+
+    def test_only_thinking_tokens_returns_none(self):
+        data = _gemini_response([
+            {"thought": True, "text": "Only thinking, no answer"},
+        ])
+        assert _extract_content(data) is None
+
+    def test_empty_parts_returns_none(self):
+        data = _gemini_response([])
+        assert _extract_content(data) is None
+
+    def test_missing_candidates_returns_none(self):
+        assert _extract_content({}) is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_text_result — JSON → SpeechTurnTextResult
+# ---------------------------------------------------------------------------
+
+class TestParseTextResult:
+    def test_valid_translate_request(self):
+        result = _parse_text_result(VALID_JSON, "I want to ask a girl out")
+        assert result.intent == "translate_request"
+        assert result.chinese == "我想约你出去约会"
+        assert result.pinyin == "wǒ xiǎng yuē nǐ chūqù yuēhuì"
+        assert len(result.notes) == 1
+
+    def test_unknown_intent_clears_chinese(self):
+        payload = json.dumps({
+            "normalized_request": "Hello",
+            "intent": "unknown",
+            "target_text": "",
+            "romanization": "",
+            "chinese": "你好",
+            "pinyin": "nǐ hǎo",
+            "notes": [],
+        })
+        result = _parse_text_result(payload, "Hello")
+        assert result.intent == "unknown"
+        assert result.chinese == ""
+        assert result.pinyin == ""
+
+    def test_invalid_json_returns_fallback(self):
+        """Thinking token text (non-JSON) must fall back gracefully."""
+        result = _parse_text_result(
+            "Let me think about how to translate this phrase...",
+            "I want to ask a girl out",
+        )
+        assert result.intent == "unknown"
+        assert result.chinese == ""
+        assert result.pinyin == ""
+        assert any("Unable to parse" in n for n in result.notes)
+
+    def test_markdown_wrapped_json_is_stripped(self):
+        wrapped = f"```json\n{VALID_JSON}\n```"
+        result = _parse_text_result(wrapped, "test")
+        assert result.intent == "translate_request"
+        assert result.chinese == "我想约你出去约会"
+
+    def test_truncated_json_returns_fallback(self):
+        truncated = VALID_JSON[:40]  # cut mid-object
+        result = _parse_text_result(truncated, "test")
+        assert result.intent == "unknown"
+        assert any("Unable to parse" in n for n in result.notes)
+
+
+# ---------------------------------------------------------------------------
+# _build_response_parts — assembles final chinese/pinyin/tts_text
+# ---------------------------------------------------------------------------
+
+class TestBuildResponseParts:
+    def test_translate_request_with_chinese(self):
+        result = _parse_text_result(VALID_JSON, "test")
+        chinese, pinyin, notes, tts_text = _build_response_parts("test", result)
+        assert chinese == "我想约你出去约会"
+        assert pinyin == "wǒ xiǎng yuē nǐ chūqù yuēhuì"
+        assert tts_text == "我想约你出去约会"
+
+    def test_translate_request_missing_chinese_adds_note(self):
+        payload = json.dumps({
+            "normalized_request": "test",
+            "intent": "translate_request",
+            "target_text": "",
+            "romanization": "",
+            "chinese": "",
+            "pinyin": "",
+            "notes": [],
+        })
+        result = _parse_text_result(payload, "test")
+        chinese, pinyin, notes, tts_text = _build_response_parts("test", result)
+        assert chinese == ""
+        assert any("incomplete" in n.lower() for n in notes)
+        assert tts_text == "I heard: test"

--- a/backend/tests/test_speech_turn_contract.py
+++ b/backend/tests/test_speech_turn_contract.py
@@ -40,7 +40,6 @@ class FakeSpeechTurnService:
     async def synthesize_audio(
         self, *, tts_text: str, target_lang: str, base_url: str, voice_name: str = "Kore"
     ):
-    async def synthesize_audio(self, *, tts_text: str, target_lang: str, base_url: str):
         return (
             SpeechTurnAudio(format="mp3", url=f"{base_url}static/audio/mock.mp3"),
             f"{base_url}static/audio/mock.mp3",

--- a/backend/tests/test_speech_turn_schema.py
+++ b/backend/tests/test_speech_turn_schema.py
@@ -40,7 +40,6 @@ class FakeSpeechTurnService:
     async def synthesize_audio(
         self, *, tts_text: str, target_lang: str, base_url: str, voice_name: str = "Kore"
     ):
-    async def synthesize_audio(self, *, tts_text: str, target_lang: str, base_url: str):
         return (
             SpeechTurnAudio(format="mp3", url=f"{base_url}static/audio/mock.mp3"),
             f"{base_url}static/audio/mock.mp3",

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1327,7 +1327,7 @@ export default function App() {
       </View>
       <KeyboardAvoidingView
         style={styles.keyboardAvoid}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        behavior="padding"
         keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 24}
       >
         <Animated.View


### PR DESCRIPTION
## Summary
Updates response parsing across multiple Gemini API integrations to correctly handle thinking tokens (extended thinking feature in Gemini 2.5+). The Gemini API now prepends `thought` parts before the actual response, which were being incorrectly extracted as content.

## Key Changes

- **`backend/app/services/gemini_stt.py`**: Updated `transcribe_raw()` and `normalize_transcript()` to skip parts where `thought=True` and extract the first actual text part
- **`backend/app/services/speech_turn.py`**: 
  - Fixed response parsing in `generate()` to skip thinking tokens
  - Increased `maxOutputTokens` from 256 to 512 to accommodate extended thinking
  - Added explanatory comment about thinking token handling
- **`backend/tests/test_gemini_parsing.py`**: Added comprehensive unit tests covering:
  - Plain responses without thinking tokens
  - Single and multiple thinking tokens followed by actual response
  - Edge cases (only thinking tokens, empty parts, missing candidates)
  - JSON parsing with markdown wrapping and truncation
  - Response part assembly logic
- **`mobile/App.tsx`**: Simplified `KeyboardAvoidingView` behavior to use `"padding"` consistently across platforms
- **Test files**: Fixed duplicate method declarations in test contract/schema files

## Implementation Details

The fix uses a generator expression pattern to safely iterate through response parts:
```python
content = next(
    (p.get("text") for p in parts if not p.get("thought") and p.get("text")),
    None,
)
```

This approach:
- Skips any part with `thought=True`
- Returns the first part with actual text content
- Gracefully handles empty or missing parts by returning `None`
- Maintains backward compatibility with responses that don't include thinking tokens

https://claude.ai/code/session_01UpnwffVKi6ZuJ3zkFnEdU3