### PR TITLE
Add hold-duration recording ring and thinking pulse

### DIFF
--- a/mobile/src/components/VoiceStage.tsx
+++ b/mobile/src/components/VoiceStage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Animated,
   Easing,
@@ -69,6 +69,8 @@ const VoiceStage = ({
   const pressAnim  = useRef(new Animated.Value(0)).current;
   const pulseAnim  = useRef(new Animated.Value(1)).current;
   const ringAnim   = useRef(new Animated.Value(0)).current;
+  const [hasEnoughRecording, setHasEnoughRecording] = useState(false);
+  const enoughTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scale = useRef(pressAnim.interpolate({ inputRange: [0, 1], outputRange: [1, 0.92] })).current;
 
   const isListening  = state === "listening";
@@ -85,25 +87,25 @@ const VoiceStage = ({
 
   useEffect(() => {
     if (isListening) {
-      const loop = Animated.loop(
-        Animated.sequence([
-          Animated.timing(ringAnim, {
-            toValue: 1,
-            duration: 1200,
-            easing: Easing.out(Easing.ease),
-            useNativeDriver: true,
-          }),
-          Animated.timing(ringAnim, {
-            toValue: 0,
-            duration: 0,
-            useNativeDriver: true,
-          }),
-        ])
-      );
-      loop.start();
-      return () => loop.stop();
+      setHasEnoughRecording(false);
+      Animated.timing(ringAnim, {
+        toValue: 1,
+        duration: 2000,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start();
+      enoughTimerRef.current = setTimeout(() => {
+        setHasEnoughRecording(true);
+      }, 2000);
+      return () => {
+        if (enoughTimerRef.current) {
+          clearTimeout(enoughTimerRef.current);
+          enoughTimerRef.current = null;
+        }
+      };
     }
     ringAnim.setValue(0);
+    setHasEnoughRecording(false);
   }, [isListening, ringAnim]);
 
   useEffect(() => {
@@ -140,11 +142,11 @@ const VoiceStage = ({
 
   const ringScale = ringAnim.interpolate({
     inputRange: [0, 1],
-    outputRange: [1, 1.6],
+    outputRange: [1, 1.9],
   });
   const ringOpacity = ringAnim.interpolate({
     inputRange: [0, 0.8, 1],
-    outputRange: [0.5, 0.1, 0],
+    outputRange: [0.55, 0.45, 0.35],
   });
 
   return (
@@ -154,7 +156,7 @@ const VoiceStage = ({
           style={[
             styles.ring,
             {
-              backgroundColor: ring,
+              backgroundColor: hasEnoughRecording ? "#22C55E" : ring,
               transform: [{ scale: ringScale }],
               opacity: ringOpacity,
             },
@@ -175,7 +177,15 @@ const VoiceStage = ({
           <Text style={styles.icon}>{STATE_ICON[state]}</Text>
         </Pressable>
       </Animated.View>
-      <Text style={[styles.label, { color: bg }]}>{STATE_LABEL[state]}</Text>
+      {isProcessing ? (
+        <Animated.Text
+          style={[styles.label, styles.processingLabel, { color: bg, opacity: pulseAnim }]}
+        >
+          Thinking...
+        </Animated.Text>
+      ) : (
+        <Text style={[styles.label, { color: bg }]}>{STATE_LABEL[state]}</Text>
+      )}
     </View>
   );
 };
@@ -215,6 +225,10 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: "600",
     letterSpacing: 0.2,
+  },
+  processingLabel: {
+    minWidth: 100,
+    textAlign: "center",
   },
 });
 


### PR DESCRIPTION
### Motivation
- Provide clear visual feedback while the user holds the mic: an expanding ring that represents recording duration and signals when the recording is long enough. 
- Indicate backend processing after release with a pulsing `Thinking...` label so users understand the app is working.

### Description
- Replace the previous looping ring with a duration-based expand using `Animated.timing` that grows over 2 seconds while `state === "listening"`.
- Add `hasEnoughRecording` state and a `setTimeout` (`enoughTimerRef`) to flip the indicator after 2 seconds and change the ring color to green (`#22C55E`).
- Adjust ring scale and opacity interpolation to emphasize the outward growth and make the visual more prominent.
- Show a pulsing `Thinking...` `Animated.Text` bound to the existing `pulseAnim` while `state === "processing"`, and add a small `processingLabel` style for layout.
- Ensure the `enoughTimerRef` is cleared when listening stops to avoid dangling timers and reset `hasEnoughRecording` when appropriate.

### Testing
- Ran TypeScript checks with `cd mobile && npx tsc --noEmit`, which completed successfully (no type errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1b0aa1a048333a543b10ec70a49f5)