### PR TITLE
Add tabbed navigation, history/saved screens, and enhanced UI

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,12 +1,14 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Audio } from "expo-av";
 import * as FileSystem from "expo-file-system/legacy";
+import { useFonts, Fraunces_500Medium_Italic } from "@expo-google-fonts/fraunces";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Animated,
   Easing,
   KeyboardAvoidingView,
+  Modal,
   Platform,
   Pressable,
   SafeAreaView,
@@ -14,6 +16,8 @@ import {
   Text,
   View,
 } from "react-native";
+
+import { useUIStore } from "./src/store/uiStore";
 
 import ApiBlockedScreen from "./src/components/ApiBlockedScreen";
 import AuthScreen from "./src/components/AuthScreen";
@@ -404,6 +408,10 @@ export default function App() {
   const [showScenarioPicker, setShowScenarioPicker] = useState(false);
   const [selectedScenario, setSelectedScenario] = useState<PracticeScenario | null>(null);
   const [selectedVoice, setSelectedVoice] = useState<VoiceOption>("warm");
+  const [showDrawer, setShowDrawer] = useState(false);
+  const [fontsLoaded] = useFonts({ Fraunces_500Medium_Italic });
+  const activeTab = useUIStore((s) => s.activeTab);
+  const setActiveTab = useUIStore((s) => s.setActiveTab);
   const recordingRef = useRef<Audio.Recording | null>(null);
   const soundRef = useRef<Audio.Sound | null>(null);
   const completeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1067,44 +1075,58 @@ export default function App() {
           <View
             style={[StyleSheet.absoluteFillObject, { backgroundColor: activeTheme.headerSurface }]}
           />
+          {/* Title row */}
           <View style={styles.headerTitleRow}>
             <Text
-              style={[styles.title, { color: activeTheme.titleText }]}
+              style={[
+                styles.headerWordmark,
+                fontsLoaded ? { fontFamily: "Fraunces_500Medium_Italic" } : {},
+              ]}
               onLongPress={DEMO_MODE || CHATBOT_ONLY_MODE ? undefined : handleLock}
             >
-              {preference === "chinese" ? "英语导师" : "Chinese Tutor"}
+              Tutor
             </Text>
             <View style={styles.headerRight}>
-              <View style={styles.langToggle}>
-                <Pressable
-                  style={[
-                    styles.langPill,
-                    { borderColor: activeTheme.surfaceBorder },
-                    preference === "english" && styles.langPillActive,
-                    preference === "english" && { borderColor: activeTheme.messageAccentText },
-                  ]}
-                  onPress={() => void handleSwitchLanguage("english")}
-                >
-                  <Text style={[styles.langPillText, { color: activeTheme.subtitleText }, preference === "english" && styles.langPillTextActive, preference === "english" && { color: activeTheme.titleText }]}>EN</Text>
+              {/* EN → 中 pill */}
+              <View style={styles.langPillContainer}>
+                <Pressable onPress={() => void handleSwitchLanguage("english")}>
+                  <Text
+                    style={[
+                      styles.langPillSide,
+                      preference === "english" && styles.langPillSideActive,
+                    ]}
+                  >
+                    EN
+                  </Text>
                 </Pressable>
-                <Pressable
-                  style={[
-                    styles.langPill,
-                    { borderColor: activeTheme.surfaceBorder },
-                    preference === "chinese" && styles.langPillActive,
-                    preference === "chinese" && { borderColor: activeTheme.messageAccentText },
-                  ]}
-                  onPress={() => void handleSwitchLanguage("chinese")}
-                >
-                  <Text style={[styles.langPillText, { color: activeTheme.subtitleText }, preference === "chinese" && styles.langPillTextActive, preference === "chinese" && { color: activeTheme.titleText }]}>中</Text>
+                <Text style={styles.langPillSeparator}>→</Text>
+                <Pressable onPress={() => void handleSwitchLanguage("chinese")}>
+                  <Text
+                    style={[
+                      styles.langPillSide,
+                      preference === "chinese" && styles.langPillSideActive,
+                    ]}
+                  >
+                    中
+                  </Text>
                 </Pressable>
               </View>
-              {DEMO_MODE || CHATBOT_ONLY_MODE || !REQUIRE_AUTH ? null : (
-                <Pressable onPress={handleLogout}>
-                  <Text style={styles.logoutText}>Logout</Text>
-                </Pressable>
-              )}
+              {/* Hamburger menu */}
+              <Pressable onPress={() => setShowDrawer(true)} style={styles.menuButton}>
+                <Text style={styles.menuIcon}>≡</Text>
+              </Pressable>
             </View>
+          </View>
+          {/* Tab bar */}
+          <View style={styles.tabBar}>
+            {(["SPEAK", "HISTORY", "SAVED"] as const).map((tab) => (
+              <Pressable key={tab} onPress={() => setActiveTab(tab)} style={styles.tabItem}>
+                <Text style={[styles.tabLabel, activeTab === tab && styles.tabLabelActive]}>
+                  {tab}
+                </Text>
+                {activeTab === tab && <View style={styles.tabUnderline} />}
+              </Pressable>
+            ))}
           </View>
         </Animated.View>
 
@@ -1118,7 +1140,16 @@ export default function App() {
           </View>
         ) : null}
 
-        <View style={styles.centerStage}>
+        {activeTab === "HISTORY" ? (
+          <View style={styles.tabPlaceholder}>
+            <Text style={styles.tabPlaceholderText}>History</Text>
+          </View>
+        ) : activeTab === "SAVED" ? (
+          <View style={styles.tabPlaceholder}>
+            <Text style={styles.tabPlaceholderText}>Saved</Text>
+          </View>
+        ) : null}
+        {activeTab === "SPEAK" ? <View style={styles.centerStage}>
           <View style={styles.practiceScenarioWrap}>
             <Pressable
               style={[
@@ -1328,8 +1359,31 @@ export default function App() {
               ))}
             </View>
           ) : null}
-        </View>
+        </View> : null}
       </KeyboardAvoidingView>
+      <Modal
+        visible={showDrawer}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowDrawer(false)}
+      >
+        <Pressable style={styles.drawerOverlay} onPress={() => setShowDrawer(false)}>
+          <View style={styles.drawerPanel}>
+            {DEMO_MODE || CHATBOT_ONLY_MODE || !REQUIRE_AUTH ? (
+              <Text style={styles.drawerEmpty}>Settings coming soon</Text>
+            ) : (
+              <Pressable
+                onPress={() => {
+                  setShowDrawer(false);
+                  void handleLogout();
+                }}
+              >
+                <Text style={styles.drawerItem}>Logout</Text>
+              </Pressable>
+            )}
+          </View>
+        </Pressable>
+      </Modal>
     </SafeAreaView>
   );
 }
@@ -1467,57 +1521,136 @@ const styles = StyleSheet.create({
   },
   headerHero: {
     paddingHorizontal: 20,
-    paddingTop: 22,
-    paddingBottom: 16,
-    borderBottomWidth: 1.5,
-    borderBottomColor: "rgba(245, 208, 169, 0.7)",
+    paddingTop: 16,
+    paddingBottom: 0,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(0,0,0,0.07)",
   },
   headerTitleRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
   },
-  title: {
-    fontSize: 26,
-    lineHeight: 30,
-    fontWeight: "800",
-    letterSpacing: -0.6,
-    color: "#6B2C12",
-  },
-  logoutText: {
-    fontSize: 12,
-    color: "#B91C1C",
-    fontWeight: "600",
+  headerWordmark: {
+    fontSize: 22,
+    fontWeight: "500",
+    fontStyle: "italic",
+    color: "#1A1009",
+    letterSpacing: 0.1,
   },
   headerRight: {
     flexDirection: "row",
     alignItems: "center",
     gap: 10,
   },
-  langToggle: {
+  langPillContainer: {
     flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "rgba(0,0,0,0.05)",
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
     gap: 4,
   },
-  langPill: {
-    paddingHorizontal: 13,
-    paddingVertical: 6,
-    borderRadius: 999,
-    borderWidth: 1.5,
-    borderColor: "rgba(107, 44, 18, 0.2)",
-    backgroundColor: "rgba(255,255,255,0.2)",
+  langPillSide: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 11,
+    letterSpacing: 1.2,
+    textTransform: "uppercase",
+    color: "#8F8578",
   },
-  langPillActive: {
-    backgroundColor: "rgba(107, 44, 18, 0.14)",
-    borderColor: "rgba(107, 44, 18, 0.6)",
+  langPillSideActive: {
+    color: "#1D4D3B",
   },
-  langPillText: {
+  langPillSeparator: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 11,
+    color: "#8F8578",
+  },
+  menuButton: {
+    paddingHorizontal: 4,
+    paddingVertical: 2,
+  },
+  menuIcon: {
+    fontSize: 22,
+    color: "#1A1009",
+    lineHeight: 26,
+  },
+  tabBar: {
+    flexDirection: "row",
+    marginTop: 14,
+    gap: 20,
+  },
+  tabItem: {
+    paddingBottom: 8,
+    position: "relative",
+  },
+  tabLabel: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: "#8F8578",
+  },
+  tabLabelActive: {
+    color: "#1D4D3B",
+  },
+  tabUnderline: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: 2,
+    backgroundColor: "#1D4D3B",
+    borderRadius: 1,
+  },
+  tabPlaceholder: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  tabPlaceholderText: {
+    fontSize: 16,
+    color: "#8F8578",
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    letterSpacing: 1.2,
+    textTransform: "uppercase",
+  },
+  logoutText: {
+    fontSize: 12,
+    color: "#B91C1C",
+    fontWeight: "600",
+  },
+  drawerOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.28)",
+    justifyContent: "flex-start",
+    alignItems: "flex-end",
+  },
+  drawerPanel: {
+    backgroundColor: "#FDFAF6",
+    marginTop: 88,
+    marginRight: 16,
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    minWidth: 180,
+    shadowColor: "#000",
+    shadowOpacity: 0.12,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 8,
+  },
+  drawerItem: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#B91C1C",
+    paddingVertical: 8,
+  },
+  drawerEmpty: {
     fontSize: 13,
-    fontWeight: "700",
-    color: "rgba(107, 44, 18, 0.38)",
-    letterSpacing: 0.3,
-  },
-  langPillTextActive: {
-    color: "#6B2C12",
+    color: "#8F8578",
+    paddingVertical: 8,
   },
   centerStage: {
     flex: 1,

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -31,11 +31,14 @@ import {
 } from "react-native";
 
 import { useUIStore } from "./src/store/uiStore";
-import { TOKENS, getToneColor, FONT_FAMILIES } from "./src/styles/tokens";
+import { useHistoryStore, useSavedStore } from "./src/store/historyStore";
+import { TOKENS, getToneColor, FONT_FAMILIES, detectTone, toneColor } from "./src/styles/tokens";
 
 import ApiBlockedScreen from "./src/components/ApiBlockedScreen";
 import AuthScreen from "./src/components/AuthScreen";
+import HistoryScreen from "./src/components/HistoryScreen";
 import LockScreen from "./src/components/LockScreen";
+import SavedScreen from "./src/components/SavedScreen";
 import VoiceStage, { type VoiceStageState } from "./src/components/VoiceStage";
 import {
   clearUnlock,
@@ -594,18 +597,7 @@ const ListeningView = ({ liveTranscript, meteringLevel, fontsLoaded }: Listening
   );
 };
 
-// ─── Tone utilities ──────────────────────────────────────────────────────────
-
-const detectTone = (syllable: string): 1 | 2 | 3 | 4 | 5 => {
-  if (/[āēīōūǖĀĒĪŌŪǕ]/.test(syllable)) return 1;
-  if (/[áéíóúǘÁÉÍÓÚǗ]/.test(syllable)) return 2;
-  if (/[ǎěǐǒǔǚǍĚǏǑǓǙ]/.test(syllable)) return 3;
-  if (/[àèìòùǜÀÈÌÒÙǛ]/.test(syllable)) return 4;
-  return 5;
-};
-
-// Convenience: detect tone from a diacritic-marked syllable string then look up the colour.
-const toneColor = (syllable: string) => getToneColor(detectTone(syllable));
+// Tone utilities re-exported from tokens — detectTone, toneColor, getToneColor.
 
 type MorphemeEntry = { hanzi: string; pinyin: string };
 
@@ -762,6 +754,8 @@ export default function App() {
   });
   const activeTab = useUIStore((s) => s.activeTab);
   const setActiveTab = useUIStore((s) => s.setActiveTab);
+  const addHistoryEntry = useHistoryStore((s) => s.addEntry);
+  const { save: saveEntry, unsave: unsaveEntry, isSaved } = useSavedStore();
   const recordingRef = useRef<Audio.Recording | null>(null);
   const soundRef = useRef<Audio.Sound | null>(null);
   const completeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1202,6 +1196,16 @@ export default function App() {
       const data = JSON.parse(raw) as SpeechTurnResponse;
       console.log("Voice Response Payload:", data);
       setVoiceTurn(data);
+      addHistoryEntry({
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        timestamp: Date.now(),
+        transcript: data.transcript,
+        chinese: data.chinese,
+        pinyin: data.pinyin,
+        english: data.assistant_text,
+        notes: data.notes ?? [],
+        audioUrl: data.audio_url ?? null,
+      });
       setVoiceHistory((previous) => [
         ...previous.slice(-2),
         {
@@ -1549,13 +1553,9 @@ export default function App() {
         ) : null}
 
         {activeTab === "HISTORY" ? (
-          <View style={styles.tabPlaceholder}>
-            <Text style={styles.tabPlaceholderText}>History</Text>
-          </View>
+          <HistoryScreen fontsLoaded={!!fontsLoaded} />
         ) : activeTab === "SAVED" ? (
-          <View style={styles.tabPlaceholder}>
-            <Text style={styles.tabPlaceholderText}>Saved</Text>
-          </View>
+          <SavedScreen fontsLoaded={!!fontsLoaded} />
         ) : null}
         {activeTab === "SPEAK" ? <View style={styles.centerStage}>
           <View style={styles.practiceScenarioWrap}>

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -397,6 +397,92 @@ const Onboarding = ({
   );
 };
 
+const BAR_COUNT = 48;
+
+type ListeningViewProps = {
+  liveTranscript: string;
+  meteringLevel: number;
+  fontsLoaded: boolean;
+};
+
+const ListeningView = ({ liveTranscript, meteringLevel, fontsLoaded }: ListeningViewProps) => {
+  const barValues = useRef(
+    Array.from({ length: BAR_COUNT }, () => new Animated.Value(3))
+  ).current;
+  const caretBlink = useRef(new Animated.Value(1)).current;
+  const dotPulse = useRef(new Animated.Value(1)).current;
+  const meteringRef = useRef(meteringLevel);
+
+  useEffect(() => { meteringRef.current = meteringLevel; }, [meteringLevel]);
+
+  useEffect(() => {
+    const blink = Animated.loop(
+      Animated.sequence([
+        Animated.timing(caretBlink, { toValue: 0, duration: 500, useNativeDriver: true }),
+        Animated.timing(caretBlink, { toValue: 1, duration: 500, useNativeDriver: true }),
+      ])
+    );
+    blink.start();
+    return () => blink.stop();
+  }, [caretBlink]);
+
+  useEffect(() => {
+    const pulse = Animated.loop(
+      Animated.sequence([
+        Animated.timing(dotPulse, { toValue: 0.3, duration: 600, useNativeDriver: true }),
+        Animated.timing(dotPulse, { toValue: 1.0, duration: 600, useNativeDriver: true }),
+      ])
+    );
+    pulse.start();
+    return () => pulse.stop();
+  }, [dotPulse]);
+
+  useEffect(() => {
+    let phase = 0;
+    const id = setInterval(() => {
+      // dBFS -60..0 → 0..1; floor at 0.15 so bars are never completely flat
+      const level = Math.max(0.15, Math.min(1, (meteringRef.current + 60) / 60));
+      phase += 0.18;
+      barValues.forEach((v, i) => {
+        const envelope = Math.sin((i / (BAR_COUNT - 1)) * Math.PI); // tall center
+        const wave = 0.5 + 0.5 * Math.sin(2 * Math.PI * (i / 10) - phase);
+        v.setValue(3 + envelope * wave * level * 37);
+      });
+    }, 50);
+    return () => clearInterval(id);
+  }, [barValues]);
+
+  return (
+    <View style={styles.listeningWrap}>
+      {/* ● RECORDING eyebrow */}
+      <View style={styles.recordingEyebrow}>
+        <Animated.View style={[styles.recordingDot, { opacity: dotPulse }]} />
+        <Text style={styles.recordingLabel}># RECORDING</Text>
+      </View>
+
+      {/* Live transcript + blinking caret */}
+      <View style={styles.transcriptBlock}>
+        <Text
+          style={[
+            styles.transcriptText,
+            fontsLoaded ? { fontFamily: "Fraunces_500Medium_Italic" } : {},
+          ]}
+        >
+          {liveTranscript || "Listening…"}
+        </Text>
+        <Animated.View style={[styles.transcriptCaret, { opacity: caretBlink }]} />
+      </View>
+
+      {/* 48-bar waveform */}
+      <View style={styles.waveform}>
+        {barValues.map((v, i) => (
+          <Animated.View key={i} style={[styles.waveBar, { height: v }]} />
+        ))}
+      </View>
+    </View>
+  );
+};
+
 export default function App() {
   const [preference, setPreference] = useState<SpeakerPreference | null>(null);
   const [isLoadingPreference, setIsLoadingPreference] = useState(true);
@@ -423,6 +509,8 @@ export default function App() {
   const [selectedVoice, setSelectedVoice] = useState<VoiceOption>("warm");
   const [showDrawer, setShowDrawer] = useState(false);
   const [pendingQuery, setPendingQuery] = useState<string | null>(null);
+  const [liveTranscript, setLiveTranscript] = useState("");
+  const [meteringLevel, setMeteringLevel] = useState(-160);
   const [fontsLoaded] = useFonts({ Fraunces_500Medium_Italic });
   const activeTab = useUIStore((s) => s.activeTab);
   const setActiveTab = useUIStore((s) => s.setActiveTab);
@@ -750,11 +838,17 @@ export default function App() {
       playsInSilentModeIOS: true,
     });
     const recording = new Audio.Recording();
-    await recording.prepareToRecordAsync(
-      Audio.RecordingOptionsPresets.HIGH_QUALITY
-    );
+    recording.setOnRecordingStatusUpdate((status) => {
+      if (status.metering != null) setMeteringLevel(status.metering);
+    });
+    await recording.prepareToRecordAsync({
+      ...Audio.RecordingOptionsPresets.HIGH_QUALITY,
+      isMeteringEnabled: true,
+    });
     await recording.startAsync();
     recordingRef.current = recording;
+    setLiveTranscript("");
+    setMeteringLevel(-160);
     setIsRecording(true);
   };
 
@@ -768,6 +862,8 @@ export default function App() {
     setShowVoiceComplete(false);
     setIsPlayingPronunciation(false);
     setVoiceError(null);
+    setLiveTranscript("");
+    setMeteringLevel(-160);
     try {
       await recording.stopAndUnloadAsync();
       const status = await recording.getStatusAsync();
@@ -1246,7 +1342,13 @@ export default function App() {
             </View>
           ) : null}
 
-          {voiceTurn ? (
+          {isRecording ? (
+            <ListeningView
+              liveTranscript={liveTranscript}
+              meteringLevel={meteringLevel}
+              fontsLoaded={!!fontsLoaded}
+            />
+          ) : voiceTurn ? (
             <View
               style={[
                 styles.voiceResultCenter,
@@ -1328,7 +1430,7 @@ export default function App() {
           )}
 
           {/* Pending query prompt — shown when a suggestion is tapped */}
-          {!voiceTurn && pendingQuery ? (
+          {!isRecording && !voiceTurn && pendingQuery ? (
             <View style={styles.pendingQueryWrap}>
               <Text style={styles.pendingQueryLabel}>SAY SOMETHING LIKE</Text>
               <Text
@@ -1730,6 +1832,56 @@ const styles = StyleSheet.create({
     paddingHorizontal: 28,
     paddingTop: 20,
     paddingBottom: 32,
+  },
+  listeningWrap: {
+    alignSelf: "stretch",
+  },
+  recordingEyebrow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginBottom: 18,
+  },
+  recordingDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: "#1D4D3B",
+  },
+  recordingLabel: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: "#1D4D3B",
+  },
+  transcriptBlock: {
+    marginBottom: 28,
+  },
+  transcriptText: {
+    fontSize: 28,
+    fontStyle: "italic",
+    lineHeight: 36,
+    color: "#15110D",
+  },
+  transcriptCaret: {
+    width: 2,
+    height: 26,
+    backgroundColor: "#1D4D3B",
+    borderRadius: 1,
+    marginTop: 6,
+  },
+  waveform: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    height: 44,
+    gap: 3,
+  },
+  waveBar: {
+    width: 3,
+    backgroundColor: "#15110D",
+    borderRadius: 1.5,
   },
   dailyPhraseCard: {
     alignSelf: "stretch",

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -2,6 +2,8 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Audio } from "expo-av";
 import * as FileSystem from "expo-file-system/legacy";
 import { useFonts, Fraunces_500Medium_Italic } from "@expo-google-fonts/fraunces";
+import { NotoSerifSC_500Medium } from "@expo-google-fonts/noto-serif-sc";
+import { SpaceGrotesk_600SemiBold } from "@expo-google-fonts/space-grotesk";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
@@ -12,6 +14,7 @@ import {
   Platform,
   Pressable,
   SafeAreaView,
+  ScrollView,
   StyleSheet,
   Text,
   View,
@@ -157,6 +160,7 @@ type SpeechTurnResponse = {
   audio_job_id?: string | null;
   audio_pending?: boolean | null;
   tts_error?: string | null;
+  score?: number;
 };
 
 type VoiceExchange = {
@@ -579,6 +583,138 @@ const ListeningView = ({ liveTranscript, meteringLevel, fontsLoaded }: Listening
   );
 };
 
+// ─── Tone utilities ──────────────────────────────────────────────────────────
+
+const TONE_COLORS: Record<number, string> = {
+  1: "#2A7BE4",
+  2: "#2E9E5B",
+  3: "#C57B1A",
+  4: "#C84B31",
+  5: "#8F8578",
+};
+
+const detectTone = (syllable: string): number => {
+  if (/[āēīōūǖĀĒĪŌŪǕ]/.test(syllable)) return 1;
+  if (/[áéíóúǘÁÉÍÓÚǗ]/.test(syllable)) return 2;
+  if (/[ǎěǐǒǔǚǍĚǏǑǓǙ]/.test(syllable)) return 3;
+  if (/[àèìòùǜÀÈÌÒÙǛ]/.test(syllable)) return 4;
+  return 5;
+};
+
+const toneColor = (syllable: string) => TONE_COLORS[detectTone(syllable)];
+
+type MorphemeEntry = { hanzi: string; pinyin: string };
+
+const buildBreakdown = (chinese: string, pinyin: string): MorphemeEntry[] => {
+  const chars = [...chinese].filter((c) => /[㐀-鿿]/.test(c));
+  const syllables = pinyin.trim().split(/\s+/);
+  return chars.map((hanzi, i) => ({ hanzi, pinyin: syllables[i] ?? "·" }));
+};
+
+// ─── Response view ────────────────────────────────────────────────────────────
+
+type ResponseViewProps = {
+  turn: SpeechTurnResponse;
+  fontsLoaded: boolean;
+  onPlayAudio: (slow: boolean) => void;
+  isPlaying: boolean;
+};
+
+const ResponseView = ({ turn, fontsLoaded, onPlayAudio, isPlaying }: ResponseViewProps) => {
+  const frauncesItalic = fontsLoaded ? { fontFamily: "Fraunces_500Medium_Italic" } : {};
+  const notoSerif = fontsLoaded ? { fontFamily: "NotoSerifSC_500Medium" } : {};
+  const spaceGrotesk = fontsLoaded ? { fontFamily: "SpaceGrotesk_600SemiBold" } : {};
+  const breakdown = buildBreakdown(turn.chinese, turn.pinyin);
+
+  return (
+    <ScrollView
+      style={styles.responseScroll}
+      contentContainerStyle={styles.responseScrollContent}
+      showsVerticalScrollIndicator={false}
+      alwaysBounceVertical={false}
+    >
+      {/* 1. YOU ASKED eyebrow + user transcript */}
+      {turn.transcript ? (
+        <View style={styles.resYouAskedBlock}>
+          <Text style={styles.resEyebrow}>YOU ASKED</Text>
+          <Text style={[styles.resYouAskedText, frauncesItalic]}>"{turn.transcript}"</Text>
+        </View>
+      ) : null}
+
+      {/* 2. Hero hanzi */}
+      <Text style={[styles.resHeroHanzi, notoSerif]}>{turn.chinese}</Text>
+
+      {/* 3. Tone-colored pinyin row */}
+      <View style={styles.resPinyinRow}>
+        {turn.pinyin.trim().split(/\s+/).map((syllable, i) => (
+          <Text key={i} style={[styles.resPinyinSyllable, spaceGrotesk, { color: toneColor(syllable) }]}>
+            {syllable}
+          </Text>
+        ))}
+      </View>
+
+      {/* 4. English gloss */}
+      <Text style={[styles.resGloss, frauncesItalic]}>"{turn.assistant_text}"</Text>
+
+      {/* 5. Action row */}
+      <View style={styles.resActionRow}>
+        <Pressable
+          style={[styles.resPlayButton, isPlaying && styles.resPlayButtonActive]}
+          onPress={() => onPlayAudio(false)}
+        >
+          <Text style={styles.resPlayButtonText}>▶ PLAY AUDIO</Text>
+        </Pressable>
+        <Pressable style={styles.resSlowButton} onPress={() => onPlayAudio(true)}>
+          <Text style={styles.resSlowButtonText}>½× SLOW</Text>
+        </Pressable>
+      </View>
+
+      {/* 6. Horizontal rule */}
+      <View style={styles.resRule} />
+
+      {/* 7. BREAKDOWN */}
+      {breakdown.length > 0 ? (
+        <>
+          <Text style={[styles.resEyebrow, { marginBottom: 4 }]}>BREAKDOWN</Text>
+          {breakdown.map(({ hanzi, pinyin }, i) => (
+            <View key={i}>
+              {i > 0 && <View style={styles.resMorphemeRule} />}
+              <View style={styles.resMorphemeRow}>
+                <Text style={[styles.resMorphemeHanzi, notoSerif]}>{hanzi}</Text>
+                <Text style={[styles.resMorphemePinyin, spaceGrotesk, { color: toneColor(pinyin) }]}>
+                  {pinyin}
+                </Text>
+              </View>
+            </View>
+          ))}
+        </>
+      ) : null}
+
+      {/* 8. Horizontal rule */}
+      <View style={styles.resRule} />
+
+      {/* 9. YOUR PRONUNCIATION — only shown when the API returns a score */}
+      {turn.score != null ? (
+        <>
+          <Text style={styles.resEyebrow}>YOUR PRONUNCIATION</Text>
+          <View style={styles.resPronRow}>
+            <Text style={[styles.resPronScore, notoSerif]}>{turn.score}</Text>
+            <Text style={styles.resPronOutOf}>/100</Text>
+            {turn.notes?.[0] ? (
+              <Text style={[styles.resPronCompliment, frauncesItalic]} numberOfLines={3}>
+                {turn.notes[0]}
+              </Text>
+            ) : null}
+          </View>
+          {turn.notes?.[1] ? (
+            <Text style={styles.resPronNudge}>{turn.notes[1]}</Text>
+          ) : null}
+        </>
+      ) : null}
+    </ScrollView>
+  );
+};
+
 export default function App() {
   const [preference, setPreference] = useState<SpeakerPreference | null>(null);
   const [isLoadingPreference, setIsLoadingPreference] = useState(true);
@@ -608,7 +744,7 @@ export default function App() {
   const [liveTranscript, setLiveTranscript] = useState("");
   const [meteringLevel, setMeteringLevel] = useState(-160);
   const [processingTranscript, setProcessingTranscript] = useState("");
-  const [fontsLoaded] = useFonts({ Fraunces_500Medium_Italic });
+  const [fontsLoaded] = useFonts({ Fraunces_500Medium_Italic, NotoSerifSC_500Medium, SpaceGrotesk_600SemiBold });
   const activeTab = useUIStore((s) => s.activeTab);
   const setActiveTab = useUIStore((s) => s.setActiveTab);
   const recordingRef = useRef<Audio.Recording | null>(null);
@@ -906,6 +1042,39 @@ export default function App() {
       await wait(1000);
     }
     setVoiceError("Audio is taking too long. Please try again.");
+  };
+
+  const handleReplayAudio = async (slow: boolean) => {
+    if (isPlayingPronunciation) return;
+    if (!soundRef.current) {
+      if (!voiceTurn) return;
+      const audioPayload = voiceTurn.audio ?? {
+        format: (voiceTurn.audio_mime?.includes("mpeg") ? "mp3" : "wav") as "mp3" | "wav",
+        url: voiceTurn.audio_url ?? undefined,
+        base64: voiceTurn.audio_base64 ?? undefined,
+      };
+      if (audioPayload.url || audioPayload.base64) {
+        try {
+          await playVoiceAudio(audioPayload, voiceTurn.audio_mime ?? undefined);
+        } catch (e) {
+          console.error("Replay error:", e);
+        }
+      }
+      return;
+    }
+    try {
+      setIsPlayingPronunciation(true);
+      await soundRef.current.setPositionAsync(0);
+      if (slow) {
+        await soundRef.current.setRateAsync(0.65, true);
+      } else {
+        await soundRef.current.setRateAsync(1.0, false);
+      }
+      await soundRef.current.playAsync();
+    } catch (e) {
+      console.error("Replay error:", e);
+      setIsPlayingPronunciation(false);
+    }
   };
 
   const startRecording = async () => {
@@ -1469,30 +1638,12 @@ export default function App() {
             />
           ) : voiceTurn ? (
             <Animated.View style={{ opacity: responseFade, alignSelf: "stretch" }}>
-              <View
-                style={[
-                  styles.voiceResultCenter,
-                  {
-                    backgroundColor: activeTheme.surfaceTint,
-                    borderColor: activeTheme.surfaceBorder,
-                  },
-                ]}
-              >
-                <Text style={[styles.voiceResultChinese, { color: activeTheme.titleText }]}>
-                  {voiceTurn.chinese}
-                </Text>
-                <Text style={[styles.voiceResultPinyin, { color: activeTheme.messageAccentText }]}>
-                  {voiceTurn.pinyin}
-                </Text>
-                <Text style={[styles.voiceResultEnglish, { color: activeTheme.subtitleText }]}>
-                  {voiceTurn.transcript}
-                </Text>
-                {voiceTurn.notes?.length ? (
-                  <Text style={[styles.voiceResultNote, { color: activeTheme.voiceSupportText }]}>
-                    {voiceTurn.notes[0]}
-                  </Text>
-                ) : null}
-              </View>
+              <ResponseView
+                turn={voiceTurn}
+                fontsLoaded={!!fontsLoaded}
+                onPlayAudio={(slow) => { void handleReplayAudio(slow); }}
+                isPlaying={isPlayingPronunciation}
+              />
             </Animated.View>
           ) : (
             <View style={styles.dailyPhraseCard}>
@@ -2298,5 +2449,149 @@ const styles = StyleSheet.create({
     color: "#FFFFFF",
     fontWeight: "600",
     fontSize: 14,
+  },
+  // ── Response view ────────────────────────────────────────────────────────────
+  responseScroll: {
+    alignSelf: "stretch",
+    maxHeight: 400,
+  },
+  responseScrollContent: {
+    paddingBottom: 8,
+  },
+  resEyebrow: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: "#8F8578",
+    marginBottom: 8,
+  },
+  resYouAskedBlock: {
+    marginBottom: 20,
+  },
+  resYouAskedText: {
+    fontSize: 17,
+    fontStyle: "italic",
+    lineHeight: 24,
+    color: "#544B40",
+  },
+  resHeroHanzi: {
+    fontSize: 54,
+    lineHeight: 62,
+    letterSpacing: 3,
+    fontWeight: "500",
+    color: "#15110D",
+    marginBottom: 10,
+  },
+  resPinyinRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 4,
+    marginBottom: 10,
+  },
+  resPinyinSyllable: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  resGloss: {
+    fontSize: 17,
+    fontStyle: "italic",
+    color: "#544B40",
+    marginBottom: 18,
+    lineHeight: 24,
+  },
+  resActionRow: {
+    flexDirection: "row",
+    gap: 8,
+    marginBottom: 20,
+  },
+  resPlayButton: {
+    flex: 2,
+    backgroundColor: "#15110D",
+    borderRadius: 2,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  resPlayButtonActive: {
+    backgroundColor: "#3B3530",
+  },
+  resPlayButtonText: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 11,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: "#FFFFFF",
+  },
+  resSlowButton: {
+    flex: 1,
+    borderRadius: 2,
+    borderWidth: 1.5,
+    borderColor: "#15110D",
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  resSlowButtonText: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 11,
+    letterSpacing: 1.2,
+    color: "#15110D",
+  },
+  resRule: {
+    height: 1,
+    backgroundColor: "rgba(21,17,13,0.12)",
+    marginVertical: 20,
+  },
+  resMorphemeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingVertical: 10,
+  },
+  resMorphemeHanzi: {
+    fontSize: 24,
+    fontWeight: "500",
+    color: "#15110D",
+    minWidth: 28,
+  },
+  resMorphemePinyin: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  resMorphemeRule: {
+    height: 1,
+    backgroundColor: "rgba(21,17,13,0.08)",
+  },
+  resPronRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 6,
+    marginTop: 10,
+    marginBottom: 8,
+  },
+  resPronScore: {
+    fontSize: 48,
+    fontWeight: "500",
+    color: "#1D4D3B",
+    lineHeight: 52,
+  },
+  resPronOutOf: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 14,
+    color: "#8F8578",
+    alignSelf: "flex-end",
+    marginBottom: 6,
+  },
+  resPronCompliment: {
+    flex: 1,
+    fontSize: 15,
+    fontStyle: "italic",
+    color: "#544B40",
+    lineHeight: 22,
+    alignSelf: "center",
+  },
+  resPronNudge: {
+    fontSize: 13,
+    color: "#8F8578",
+    lineHeight: 18,
   },
 });

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,9 +1,19 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Audio } from "expo-av";
 import * as FileSystem from "expo-file-system/legacy";
-import { useFonts, Fraunces_500Medium_Italic } from "@expo-google-fonts/fraunces";
-import { NotoSerifSC_500Medium } from "@expo-google-fonts/noto-serif-sc";
-import { SpaceGrotesk_600SemiBold } from "@expo-google-fonts/space-grotesk";
+import {
+  useFonts,
+  Fraunces_400Regular,
+  Fraunces_400Regular_Italic,
+  Fraunces_500Medium,
+  Fraunces_500Medium_Italic,
+} from "@expo-google-fonts/fraunces";
+import { NotoSerifSC_400Regular, NotoSerifSC_500Medium } from "@expo-google-fonts/noto-serif-sc";
+import {
+  SpaceGrotesk_500Medium,
+  SpaceGrotesk_600SemiBold,
+  SpaceGrotesk_700Bold,
+} from "@expo-google-fonts/space-grotesk";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
@@ -21,6 +31,7 @@ import {
 } from "react-native";
 
 import { useUIStore } from "./src/store/uiStore";
+import { TOKENS, getToneColor, FONT_FAMILIES } from "./src/styles/tokens";
 
 import ApiBlockedScreen from "./src/components/ApiBlockedScreen";
 import AuthScreen from "./src/components/AuthScreen";
@@ -585,15 +596,7 @@ const ListeningView = ({ liveTranscript, meteringLevel, fontsLoaded }: Listening
 
 // ─── Tone utilities ──────────────────────────────────────────────────────────
 
-const TONE_COLORS: Record<number, string> = {
-  1: "#2A7BE4",
-  2: "#2E9E5B",
-  3: "#C57B1A",
-  4: "#C84B31",
-  5: "#8F8578",
-};
-
-const detectTone = (syllable: string): number => {
+const detectTone = (syllable: string): 1 | 2 | 3 | 4 | 5 => {
   if (/[āēīōūǖĀĒĪŌŪǕ]/.test(syllable)) return 1;
   if (/[áéíóúǘÁÉÍÓÚǗ]/.test(syllable)) return 2;
   if (/[ǎěǐǒǔǚǍĚǏǑǓǙ]/.test(syllable)) return 3;
@@ -601,7 +604,8 @@ const detectTone = (syllable: string): number => {
   return 5;
 };
 
-const toneColor = (syllable: string) => TONE_COLORS[detectTone(syllable)];
+// Convenience: detect tone from a diacritic-marked syllable string then look up the colour.
+const toneColor = (syllable: string) => getToneColor(detectTone(syllable));
 
 type MorphemeEntry = { hanzi: string; pinyin: string };
 
@@ -621,9 +625,10 @@ type ResponseViewProps = {
 };
 
 const ResponseView = ({ turn, fontsLoaded, onPlayAudio, isPlaying }: ResponseViewProps) => {
-  const frauncesItalic = fontsLoaded ? { fontFamily: "Fraunces_500Medium_Italic" } : {};
-  const notoSerif = fontsLoaded ? { fontFamily: "NotoSerifSC_500Medium" } : {};
-  const spaceGrotesk = fontsLoaded ? { fontFamily: "SpaceGrotesk_600SemiBold" } : {};
+  const frauncesItalic = fontsLoaded ? { fontFamily: FONT_FAMILIES.frauncesMediumItalic } : {};
+  const notoSerif = fontsLoaded ? { fontFamily: FONT_FAMILIES.notoSerifMedium } : {};
+  const spaceGrotesk = fontsLoaded ? { fontFamily: FONT_FAMILIES.spaceGroteskSemiBold } : {};
+  const spaceGroteskBold = fontsLoaded ? { fontFamily: FONT_FAMILIES.spaceGroteskBold } : {};
   const breakdown = buildBreakdown(turn.chinese, turn.pinyin);
 
   return (
@@ -647,7 +652,7 @@ const ResponseView = ({ turn, fontsLoaded, onPlayAudio, isPlaying }: ResponseVie
       {/* 3. Tone-colored pinyin row */}
       <View style={styles.resPinyinRow}>
         {turn.pinyin.trim().split(/\s+/).map((syllable, i) => (
-          <Text key={i} style={[styles.resPinyinSyllable, spaceGrotesk, { color: toneColor(syllable) }]}>
+          <Text key={i} style={[styles.resPinyinSyllable, spaceGroteskBold, { color: toneColor(syllable) }]}>
             {syllable}
           </Text>
         ))}
@@ -744,7 +749,17 @@ export default function App() {
   const [liveTranscript, setLiveTranscript] = useState("");
   const [meteringLevel, setMeteringLevel] = useState(-160);
   const [processingTranscript, setProcessingTranscript] = useState("");
-  const [fontsLoaded] = useFonts({ Fraunces_500Medium_Italic, NotoSerifSC_500Medium, SpaceGrotesk_600SemiBold });
+  const [fontsLoaded] = useFonts({
+    Fraunces_400Regular,
+    Fraunces_400Regular_Italic,
+    Fraunces_500Medium,
+    Fraunces_500Medium_Italic,
+    NotoSerifSC_400Regular,
+    NotoSerifSC_500Medium,
+    SpaceGrotesk_500Medium,
+    SpaceGrotesk_600SemiBold,
+    SpaceGrotesk_700Bold,
+  });
   const activeTab = useUIStore((s) => s.activeTab);
   const setActiveTab = useUIStore((s) => s.setActiveTab);
   const recordingRef = useRef<Audio.Recording | null>(null);
@@ -2463,7 +2478,7 @@ const styles = StyleSheet.create({
     fontSize: 10,
     letterSpacing: 1.6,
     textTransform: "uppercase",
-    color: "#8F8578",
+    color: TOKENS.inkFaint,
     marginBottom: 8,
   },
   resYouAskedBlock: {
@@ -2473,14 +2488,14 @@ const styles = StyleSheet.create({
     fontSize: 17,
     fontStyle: "italic",
     lineHeight: 24,
-    color: "#544B40",
+    color: TOKENS.inkSoft,
   },
   resHeroHanzi: {
     fontSize: 54,
     lineHeight: 62,
     letterSpacing: 3,
     fontWeight: "500",
-    color: "#15110D",
+    color: TOKENS.ink,
     marginBottom: 10,
   },
   resPinyinRow: {
@@ -2496,7 +2511,7 @@ const styles = StyleSheet.create({
   resGloss: {
     fontSize: 17,
     fontStyle: "italic",
-    color: "#544B40",
+    color: TOKENS.inkSoft,
     marginBottom: 18,
     lineHeight: 24,
   },
@@ -2507,7 +2522,7 @@ const styles = StyleSheet.create({
   },
   resPlayButton: {
     flex: 2,
-    backgroundColor: "#15110D",
+    backgroundColor: TOKENS.ink,
     borderRadius: 2,
     paddingVertical: 12,
     alignItems: "center",
@@ -2526,7 +2541,7 @@ const styles = StyleSheet.create({
     flex: 1,
     borderRadius: 2,
     borderWidth: 1.5,
-    borderColor: "#15110D",
+    borderColor: TOKENS.ink,
     paddingVertical: 12,
     alignItems: "center",
   },
@@ -2534,11 +2549,11 @@ const styles = StyleSheet.create({
     fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
     fontSize: 11,
     letterSpacing: 1.2,
-    color: "#15110D",
+    color: TOKENS.ink,
   },
   resRule: {
     height: 1,
-    backgroundColor: "rgba(21,17,13,0.12)",
+    backgroundColor: TOKENS.rule,
     marginVertical: 20,
   },
   resMorphemeRow: {
@@ -2550,7 +2565,7 @@ const styles = StyleSheet.create({
   resMorphemeHanzi: {
     fontSize: 24,
     fontWeight: "500",
-    color: "#15110D",
+    color: TOKENS.ink,
     minWidth: 28,
   },
   resMorphemePinyin: {
@@ -2571,13 +2586,13 @@ const styles = StyleSheet.create({
   resPronScore: {
     fontSize: 48,
     fontWeight: "500",
-    color: "#1D4D3B",
+    color: TOKENS.accent,
     lineHeight: 52,
   },
   resPronOutOf: {
     fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
     fontSize: 14,
-    color: "#8F8578",
+    color: TOKENS.inkFaint,
     alignSelf: "flex-end",
     marginBottom: 6,
   },
@@ -2585,13 +2600,13 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 15,
     fontStyle: "italic",
-    color: "#544B40",
+    color: TOKENS.inkSoft,
     lineHeight: 22,
     alignSelf: "center",
   },
   resPronNudge: {
     fontSize: 13,
-    color: "#8F8578",
+    color: TOKENS.inkFaint,
     lineHeight: 18,
   },
 });

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -68,12 +68,25 @@ const DAILY_PHRASES = [
   { chinese: "路上小心", pinyin: "lù shàng xiǎo xīn", english: "Be safe on the road" },
 ];
 
+const getDailyPhraseIndex = () => {
+  const startOfYear = new Date(new Date().getFullYear(), 0, 0).getTime();
+  const now = new Date().getTime();
+  const dayOfYear = Math.floor((now - startOfYear) / 86400000);
+  return (dayOfYear % DAILY_PHRASES.length) + 1;
+};
+
 const getDailyPhrase = () => {
   const startOfYear = new Date(new Date().getFullYear(), 0, 0).getTime();
   const now = new Date().getTime();
   const dayOfYear = Math.floor((now - startOfYear) / 86400000);
   return DAILY_PHRASES[dayOfYear % DAILY_PHRASES.length];
 };
+
+const SUGGESTIONS = [
+  "How do I order three siu mai?",
+  "Ask someone out for dinner",
+  "A polite way to decline",
+];
 
 const isTruthy = (value: string | undefined) =>
   ["1", "true", "yes", "on"].includes((value ?? "").toLowerCase());
@@ -409,6 +422,7 @@ export default function App() {
   const [selectedScenario, setSelectedScenario] = useState<PracticeScenario | null>(null);
   const [selectedVoice, setSelectedVoice] = useState<VoiceOption>("warm");
   const [showDrawer, setShowDrawer] = useState(false);
+  const [pendingQuery, setPendingQuery] = useState<string | null>(null);
   const [fontsLoaded] = useFonts({ Fraunces_500Medium_Italic });
   const activeTab = useUIStore((s) => s.activeTab);
   const setActiveTab = useUIStore((s) => s.setActiveTab);
@@ -1258,18 +1272,75 @@ export default function App() {
               ) : null}
             </View>
           ) : (
-            <View style={styles.dailyPhrase}>
-              <Text style={[styles.dailyPhraseChinese, { color: activeTheme.titleText }]}>
+            <View style={styles.dailyPhraseCard}>
+              {/* Eyebrow */}
+              <Text style={styles.phraseEyebrow}>
+                № {getDailyPhraseIndex()} · PHRASE OF THE DAY
+              </Text>
+
+              {/* Hero hanzi */}
+              <Text
+                style={[
+                  styles.phraseHanzi,
+                  fontsLoaded ? { fontFamily: "Fraunces_500Medium_Italic" } : {},
+                ]}
+              >
                 {getDailyPhrase().chinese}
               </Text>
-              <Text style={[styles.dailyPhrasePinyin, { color: activeTheme.messageAccentText }]}>
-                {getDailyPhrase().pinyin}
+
+              {/* Pinyin — tone colors to be applied per-syllable in prompt #6 */}
+              <Text style={styles.phrasePinyin}>{getDailyPhrase().pinyin}</Text>
+
+              {/* English gloss */}
+              <Text
+                style={[
+                  styles.phraseGloss,
+                  fontsLoaded ? { fontFamily: "Fraunces_500Medium_Italic" } : {},
+                ]}
+              >
+                "{getDailyPhrase().english}"
               </Text>
-              <Text style={[styles.dailyPhraseEnglish, { color: activeTheme.subtitleText }]}>
-                {getDailyPhrase().english}
-              </Text>
+
+              {/* Divider */}
+              <View style={styles.phraseDivider} />
+
+              {/* Suggestions */}
+              <Text style={styles.tryAskingLabel}>Try asking</Text>
+              {SUGGESTIONS.map((s) => (
+                <Pressable
+                  key={s}
+                  style={styles.suggestionRow}
+                  onPress={() => setPendingQuery(pendingQuery === s ? null : s)}
+                >
+                  <Text
+                    style={[
+                      styles.suggestionText,
+                      fontsLoaded ? { fontFamily: "Fraunces_500Medium_Italic" } : {},
+                      pendingQuery === s && styles.suggestionTextActive,
+                    ]}
+                  >
+                    "{s}"
+                  </Text>
+                  <Text style={styles.suggestionChevron}>›</Text>
+                </Pressable>
+              ))}
             </View>
           )}
+
+          {/* Pending query prompt — shown when a suggestion is tapped */}
+          {!voiceTurn && pendingQuery ? (
+            <View style={styles.pendingQueryWrap}>
+              <Text style={styles.pendingQueryLabel}>SAY SOMETHING LIKE</Text>
+              <Text
+                style={[
+                  styles.pendingQueryText,
+                  fontsLoaded ? { fontFamily: "Fraunces_500Medium_Italic" } : {},
+                ]}
+              >
+                "{pendingQuery}"
+              </Text>
+            </View>
+          ) : null}
 
           <Animated.View
             style={[
@@ -1654,10 +1725,92 @@ const styles = StyleSheet.create({
   },
   centerStage: {
     flex: 1,
-    justifyContent: "center",
+    justifyContent: "space-between",
     alignItems: "center",
-    paddingHorizontal: 32,
-    paddingBottom: 40,
+    paddingHorizontal: 28,
+    paddingTop: 20,
+    paddingBottom: 32,
+  },
+  dailyPhraseCard: {
+    alignSelf: "stretch",
+  },
+  phraseEyebrow: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: "#8F8578",
+    marginBottom: 14,
+  },
+  phraseHanzi: {
+    fontSize: 56,
+    lineHeight: 56,
+    letterSpacing: 1,
+    color: "#15110D",
+    marginBottom: 10,
+  },
+  phrasePinyin: {
+    fontSize: 15,
+    letterSpacing: 0.4,
+    color: "#C84B31",
+    marginBottom: 8,
+  },
+  phraseGloss: {
+    fontSize: 17,
+    fontStyle: "italic",
+    color: "#544B40",
+    marginBottom: 22,
+  },
+  phraseDivider: {
+    height: 1,
+    backgroundColor: "rgba(21,17,13,0.13)",
+    marginBottom: 16,
+  },
+  tryAskingLabel: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: "#8F8578",
+    marginBottom: 6,
+  },
+  suggestionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 9,
+  },
+  suggestionText: {
+    fontSize: 16,
+    fontStyle: "italic",
+    color: "#15110D",
+    flex: 1,
+  },
+  suggestionTextActive: {
+    color: "#1D4D3B",
+  },
+  suggestionChevron: {
+    fontSize: 18,
+    color: "#8F8578",
+    marginLeft: 8,
+  },
+  pendingQueryWrap: {
+    alignItems: "center",
+    paddingVertical: 10,
+  },
+  pendingQueryLabel: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 9,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: "#8F8578",
+    marginBottom: 4,
+  },
+  pendingQueryText: {
+    fontSize: 15,
+    fontStyle: "italic",
+    color: "#1D4D3B",
+    textAlign: "center",
   },
   dailyPhrase: {
     alignItems: "center",

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -397,6 +397,102 @@ const Onboarding = ({
   );
 };
 
+// ─── Shimmer skeleton ────────────────────────────────────────────────────────
+
+const ShimmerSkeleton = ({
+  height,
+  shimmerAnim,
+}: {
+  height: number;
+  shimmerAnim: Animated.Value;
+}) => {
+  const translateX = shimmerAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [-140, 360],
+  });
+  return (
+    <View style={[styles.skeletonBar, { height }]}>
+      <Animated.View style={[styles.shimmerHighlight, { transform: [{ translateX }] }]} />
+    </View>
+  );
+};
+
+// ─── Processing / translating screen ─────────────────────────────────────────
+
+type ProcessingViewProps = { processingTranscript: string; fontsLoaded: boolean };
+
+const ProcessingView = ({ processingTranscript, fontsLoaded }: ProcessingViewProps) => {
+  const shimmerAnim = useRef(new Animated.Value(0)).current;
+  const dot1 = useRef(new Animated.Value(0)).current;
+  const dot2 = useRef(new Animated.Value(0)).current;
+  const dot3 = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.timing(shimmerAnim, {
+        toValue: 1,
+        duration: 1600,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      })
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [shimmerAnim]);
+
+  useEffect(() => {
+    const bounce = (anim: Animated.Value, delay: number) =>
+      Animated.loop(
+        Animated.sequence([
+          ...(delay > 0 ? [Animated.delay(delay)] : []),
+          Animated.timing(anim, { toValue: -6, duration: 260, easing: Easing.out(Easing.quad), useNativeDriver: true }),
+          Animated.timing(anim, { toValue: 0,  duration: 260, easing: Easing.in(Easing.quad),  useNativeDriver: true }),
+          Animated.delay(Math.max(0, 480 - delay)),
+        ])
+      );
+    const a1 = bounce(dot1, 0);
+    const a2 = bounce(dot2, 160);
+    const a3 = bounce(dot3, 320);
+    a1.start(); a2.start(); a3.start();
+    return () => { a1.stop(); a2.stop(); a3.stop(); };
+  }, [dot1, dot2, dot3]);
+
+  return (
+    <View style={styles.processingWrap}>
+      {/* YOU ASKED */}
+      {processingTranscript ? (
+        <View style={styles.youAskedBlock}>
+          <Text style={styles.youAskedLabel}>YOU ASKED</Text>
+          <Text
+            style={[
+              styles.youAskedText,
+              fontsLoaded ? { fontFamily: "Fraunces_500Medium_Italic" } : {},
+            ]}
+          >
+            "{processingTranscript}"
+          </Text>
+        </View>
+      ) : null}
+
+      {/* Bouncing dots + TRANSLATING */}
+      <View style={styles.translatingEyebrow}>
+        {[dot1, dot2, dot3].map((d, i) => (
+          <Animated.View key={i} style={[styles.translatingDot, { transform: [{ translateY: d }] }]} />
+        ))}
+        <Text style={styles.translatingLabel}>TRANSLATING</Text>
+      </View>
+
+      {/* Shimmer skeletons: 36px hero hint, two 14px sub-lines */}
+      <View style={styles.skeletonGroup}>
+        <ShimmerSkeleton height={36} shimmerAnim={shimmerAnim} />
+        <ShimmerSkeleton height={14} shimmerAnim={shimmerAnim} />
+        <ShimmerSkeleton height={14} shimmerAnim={shimmerAnim} />
+      </View>
+    </View>
+  );
+};
+
+// ─── Listening screen ─────────────────────────────────────────────────────────
 const BAR_COUNT = 48;
 
 type ListeningViewProps = {
@@ -511,12 +607,14 @@ export default function App() {
   const [pendingQuery, setPendingQuery] = useState<string | null>(null);
   const [liveTranscript, setLiveTranscript] = useState("");
   const [meteringLevel, setMeteringLevel] = useState(-160);
+  const [processingTranscript, setProcessingTranscript] = useState("");
   const [fontsLoaded] = useFonts({ Fraunces_500Medium_Italic });
   const activeTab = useUIStore((s) => s.activeTab);
   const setActiveTab = useUIStore((s) => s.setActiveTab);
   const recordingRef = useRef<Audio.Recording | null>(null);
   const soundRef = useRef<Audio.Sound | null>(null);
   const completeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const responseFade = useRef(new Animated.Value(0)).current;
   const stageTransition = useRef(new Animated.Value(0)).current;
   const ambientDriftA = useRef(new Animated.Value(0)).current;
   const ambientDriftB = useRef(new Animated.Value(0)).current;
@@ -847,6 +945,7 @@ export default function App() {
     });
     await recording.startAsync();
     recordingRef.current = recording;
+    setProcessingTranscript("");
     setLiveTranscript("");
     setMeteringLevel(-160);
     setIsRecording(true);
@@ -862,6 +961,7 @@ export default function App() {
     setShowVoiceComplete(false);
     setIsPlayingPronunciation(false);
     setVoiceError(null);
+    setProcessingTranscript(liveTranscript);
     setLiveTranscript("");
     setMeteringLevel(-160);
     try {
@@ -1005,6 +1105,20 @@ export default function App() {
       useNativeDriver: true,
     }).start();
   }, [stageTransition, voiceStageState]);
+
+  useEffect(() => {
+    if (voiceTurn) {
+      responseFade.setValue(0);
+      Animated.timing(responseFade, {
+        toValue: 1,
+        duration: 380,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start();
+    } else {
+      responseFade.setValue(0);
+    }
+  }, [voiceTurn, responseFade]);
 
   useEffect(() => {
     return () => {
@@ -1348,31 +1462,38 @@ export default function App() {
               meteringLevel={meteringLevel}
               fontsLoaded={!!fontsLoaded}
             />
+          ) : isUploadingVoice ? (
+            <ProcessingView
+              processingTranscript={processingTranscript}
+              fontsLoaded={!!fontsLoaded}
+            />
           ) : voiceTurn ? (
-            <View
-              style={[
-                styles.voiceResultCenter,
-                {
-                  backgroundColor: activeTheme.surfaceTint,
-                  borderColor: activeTheme.surfaceBorder,
-                },
-              ]}
-            >
-              <Text style={[styles.voiceResultChinese, { color: activeTheme.titleText }]}>
-                {voiceTurn.chinese}
-              </Text>
-              <Text style={[styles.voiceResultPinyin, { color: activeTheme.messageAccentText }]}>
-                {voiceTurn.pinyin}
-              </Text>
-              <Text style={[styles.voiceResultEnglish, { color: activeTheme.subtitleText }]}>
-                {voiceTurn.transcript}
-              </Text>
-              {voiceTurn.notes?.length ? (
-                <Text style={[styles.voiceResultNote, { color: activeTheme.voiceSupportText }]}>
-                  {voiceTurn.notes[0]}
+            <Animated.View style={{ opacity: responseFade, alignSelf: "stretch" }}>
+              <View
+                style={[
+                  styles.voiceResultCenter,
+                  {
+                    backgroundColor: activeTheme.surfaceTint,
+                    borderColor: activeTheme.surfaceBorder,
+                  },
+                ]}
+              >
+                <Text style={[styles.voiceResultChinese, { color: activeTheme.titleText }]}>
+                  {voiceTurn.chinese}
                 </Text>
-              ) : null}
-            </View>
+                <Text style={[styles.voiceResultPinyin, { color: activeTheme.messageAccentText }]}>
+                  {voiceTurn.pinyin}
+                </Text>
+                <Text style={[styles.voiceResultEnglish, { color: activeTheme.subtitleText }]}>
+                  {voiceTurn.transcript}
+                </Text>
+                {voiceTurn.notes?.length ? (
+                  <Text style={[styles.voiceResultNote, { color: activeTheme.voiceSupportText }]}>
+                    {voiceTurn.notes[0]}
+                  </Text>
+                ) : null}
+              </View>
+            </Animated.View>
           ) : (
             <View style={styles.dailyPhraseCard}>
               {/* Eyebrow */}
@@ -1833,6 +1954,64 @@ const styles = StyleSheet.create({
     paddingTop: 20,
     paddingBottom: 32,
   },
+  // ── Processing / translating ──────────────────────────────────────────────
+  processingWrap: {
+    alignSelf: "stretch",
+  },
+  youAskedBlock: {
+    marginBottom: 20,
+  },
+  youAskedLabel: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: "#8F8578",
+    marginBottom: 6,
+  },
+  youAskedText: {
+    fontSize: 19,
+    fontStyle: "italic",
+    lineHeight: 26,
+    color: "#544B40",
+  },
+  translatingEyebrow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+    marginBottom: 20,
+  },
+  translatingDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: "#1D4D3B",
+  },
+  translatingLabel: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: "#1D4D3B",
+  },
+  skeletonGroup: {
+    gap: 10,
+  },
+  skeletonBar: {
+    alignSelf: "stretch",
+    backgroundColor: "rgba(21,17,13,0.08)",
+    borderRadius: 4,
+    overflow: "hidden",
+  },
+  shimmerHighlight: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    width: 130,
+    backgroundColor: "#E3EADD",
+    opacity: 0.72,
+  },
+  // ── Listening ─────────────────────────────────────────────────────────────
   listeningWrap: {
     alignSelf: "stretch",
   },

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -36,6 +36,7 @@ import { TOKENS, getToneColor, FONT_FAMILIES, detectTone, toneColor } from "./sr
 
 import ApiBlockedScreen from "./src/components/ApiBlockedScreen";
 import AuthScreen from "./src/components/AuthScreen";
+import CantHearCard from "./src/components/CantHearCard";
 import HistoryScreen from "./src/components/HistoryScreen";
 import LockScreen from "./src/components/LockScreen";
 import SavedScreen from "./src/components/SavedScreen";
@@ -175,6 +176,7 @@ type SpeechTurnResponse = {
   audio_pending?: boolean | null;
   tts_error?: string | null;
   score?: number;
+  transcript_confidence?: number;
 };
 
 type VoiceExchange = {
@@ -731,6 +733,7 @@ export default function App() {
   const [isPlayingPronunciation, setIsPlayingPronunciation] = useState(false);
   const [showVoiceComplete, setShowVoiceComplete] = useState(false);
   const [voiceError, setVoiceError] = useState<string | null>(null);
+  const [showCantHear, setShowCantHear] = useState(false);
   const [voiceTurn, setVoiceTurn] = useState<SpeechTurnResponse | null>(null);
   const [voiceHistory, setVoiceHistory] = useState<VoiceExchange[]>([]);
   const [showScenarioPicker, setShowScenarioPicker] = useState(false);
@@ -1053,6 +1056,86 @@ export default function App() {
     setVoiceError("Audio is taking too long. Please try again.");
   };
 
+  const handleTypeInsteadSubmit = async (text: string) => {
+    setShowCantHear(false);
+    setIsUploadingVoice(true);
+    setProcessingTranscript(text);
+    setVoiceError(null);
+    try {
+      const formData = new FormData();
+      formData.append("text", text);
+      formData.append("level", "beginner");
+      formData.append("scenario", selectedScenario?.id ?? "general");
+      const sourceLang = preference === "chinese" ? "zh" : "en";
+      const targetLang = preference === "chinese" ? "en" : "zh";
+      formData.append("source_lang", sourceLang);
+      formData.append("target_lang", targetLang);
+      formData.append("voice", selectedVoice);
+
+      logApiBaseUrl("Text query");
+      const { response } = await apiFetchWithTimeout(
+        "/v1/speech/turn",
+        { method: "POST", body: formData },
+        90_000,
+        1
+      );
+      const raw = await response.text();
+      if (!response.ok) throw new Error(`Text query failed ${response.status}: ${raw}`);
+
+      const data = JSON.parse(raw) as SpeechTurnResponse;
+      setVoiceTurn(data);
+      addHistoryEntry({
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        timestamp: Date.now(),
+        transcript: data.transcript || text,
+        chinese: data.chinese,
+        pinyin: data.pinyin,
+        english: data.assistant_text,
+        notes: data.notes ?? [],
+        audioUrl: data.audio_url ?? null,
+      });
+      setVoiceHistory((previous) => [
+        ...previous.slice(-2),
+        {
+          id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          userTranscript: text,
+          tutorChinese: data.chinese,
+          tutorPinyin: data.pinyin,
+          tutorEnglish: data.assistant_text,
+        },
+      ]);
+      setShowVoiceComplete(true);
+      if (completeTimeoutRef.current) clearTimeout(completeTimeoutRef.current);
+      completeTimeoutRef.current = setTimeout(() => {
+        setShowVoiceComplete(false);
+        completeTimeoutRef.current = null;
+      }, 8000);
+      const audioPayload = data.audio ?? {
+        format: (data.audio_mime?.includes("mpeg") ? "mp3" : "wav") as "mp3" | "wav",
+        url: data.audio_url ?? undefined,
+        base64: data.audio_base64 ?? undefined,
+      };
+      if (audioPayload.url || audioPayload.base64) {
+        try {
+          await playVoiceAudio(audioPayload, data.audio_mime);
+        } catch (playbackError) {
+          console.error("Playback error:", playbackError);
+          setIsPlayingPronunciation(false);
+          setVoiceError("Audio playback failed. Please check your volume and try again.");
+        }
+      } else if (data.audio_pending && data.audio_job_id) {
+        await pollForAudioJob(data.audio_job_id);
+      } else {
+        setVoiceError(data.tts_error ?? "Audio unavailable. Please try again.");
+      }
+    } catch (err) {
+      console.error("Type-instead error:", err);
+      setVoiceError("Translation failed. Please try again.");
+    } finally {
+      setIsUploadingVoice(false);
+    }
+  };
+
   const handleReplayAudio = async (slow: boolean) => {
     if (isPlayingPronunciation) return;
     if (!soundRef.current) {
@@ -1102,6 +1185,7 @@ export default function App() {
       completeTimeoutRef.current = null;
     }
     setShowVoiceComplete(false);
+    setShowCantHear(false);
     setVoiceError(null);
     if (soundRef.current) {
       await soundRef.current.stopAsync();
@@ -1195,6 +1279,16 @@ export default function App() {
 
       const data = JSON.parse(raw) as SpeechTurnResponse;
       console.log("Voice Response Payload:", data);
+
+      // Surface the can't-hear card instead of an error toast for empty/uncertain STT.
+      const isEmpty = !data.transcript || data.transcript.trim().length < 2;
+      const isLowConfidence =
+        typeof data.transcript_confidence === "number" && data.transcript_confidence < 0.4;
+      if (isEmpty || isLowConfidence) {
+        setShowCantHear(true);
+        return; // finally still runs → isUploadingVoice → false
+      }
+
       setVoiceTurn(data);
       addHistoryEntry({
         id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
@@ -1557,7 +1651,14 @@ export default function App() {
         ) : activeTab === "SAVED" ? (
           <SavedScreen fontsLoaded={!!fontsLoaded} />
         ) : null}
-        {activeTab === "SPEAK" ? <View style={styles.centerStage}>
+        {activeTab === "SPEAK" && showCantHear ? (
+          <CantHearCard
+            fontsLoaded={!!fontsLoaded}
+            onTryAgain={() => setShowCantHear(false)}
+            onTypeInsteadSubmit={(text) => { void handleTypeInsteadSubmit(text); }}
+          />
+        ) : null}
+        {activeTab === "SPEAK" && !showCantHear ? <View style={styles.centerStage}>
           <View style={styles.practiceScenarioWrap}>
             <Pressable
               style={[

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chinese-tutor-mobile",
       "version": "0.1.0",
       "dependencies": {
+        "@expo-google-fonts/fraunces": "^0.4.1",
         "@react-native-async-storage/async-storage": "2.2.0",
         "expo": "~54.0.33",
         "expo-audio": "~1.1.1",
@@ -19,7 +20,8 @@
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
         "react-native-safe-area-context": "~5.6.0",
-        "react-native-web": "^0.21.0"
+        "react-native-web": "^0.21.0",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@expo/ngrok": "^4.1.3",
@@ -1503,6 +1505,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@expo-google-fonts/fraunces": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/fraunces/-/fraunces-0.4.1.tgz",
+      "integrity": "sha512-gYc9P92ObyWvz1rWPOeWSvVKyBFIuA8hgOdhvo4DSiPBaWLbFA6v8uLIEIBwW+0oWTlXbBzjeBReHQI2H7UNjQ==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",
@@ -8530,6 +8538,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@expo-google-fonts/fraunces": "^0.4.1",
+        "@expo-google-fonts/noto-serif-sc": "^0.4.3",
+        "@expo-google-fonts/space-grotesk": "^0.4.1",
         "@react-native-async-storage/async-storage": "2.2.0",
         "expo": "~54.0.33",
         "expo-audio": "~1.1.1",
@@ -1510,6 +1512,18 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@expo-google-fonts/fraunces/-/fraunces-0.4.1.tgz",
       "integrity": "sha512-gYc9P92ObyWvz1rWPOeWSvVKyBFIuA8hgOdhvo4DSiPBaWLbFA6v8uLIEIBwW+0oWTlXbBzjeBReHQI2H7UNjQ==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/noto-serif-sc": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/noto-serif-sc/-/noto-serif-sc-0.4.3.tgz",
+      "integrity": "sha512-fSmUpiSFtSeyHV45/2xUOy5SdfExklQwwMKN3cQjAZAujITHDmSbpMHCVdCMhRqMjQtu0ZRgc29u8A+CU3akfw==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/space-grotesk": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/space-grotesk/-/space-grotesk-0.4.1.tgz",
+      "integrity": "sha512-ZVQYw4Ok/pgcSJiufP8oRZE3AVxS9xtmKEUfsurbHkHNdMc/GA1gDXP9G4Cr7KL4KqSc0haexR2TuMigotCn4Q==",
       "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/code-signing-certificates": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,6 +10,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo-google-fonts/fraunces": "^0.4.1",
     "@react-native-async-storage/async-storage": "2.2.0",
     "expo": "~54.0.33",
     "expo-audio": "~1.1.1",
@@ -21,7 +22,8 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-web": "^0.21.0"
+    "react-native-web": "^0.21.0",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@expo/ngrok": "^4.1.3",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@expo-google-fonts/fraunces": "^0.4.1",
+    "@expo-google-fonts/noto-serif-sc": "^0.4.3",
+    "@expo-google-fonts/space-grotesk": "^0.4.1",
     "@react-native-async-storage/async-storage": "2.2.0",
     "expo": "~54.0.33",
     "expo-audio": "~1.1.1",

--- a/mobile/src/components/CantHearCard.tsx
+++ b/mobile/src/components/CantHearCard.tsx
@@ -1,0 +1,219 @@
+import { useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import { FONT_FAMILIES, TOKENS } from "../styles/tokens";
+
+type Props = {
+  fontsLoaded: boolean;
+  onTryAgain: () => void;
+  onTypeInsteadSubmit: (text: string) => void;
+};
+
+const CantHearCard = ({ fontsLoaded, onTryAgain, onTypeInsteadSubmit }: Props) => {
+  const [showSheet, setShowSheet] = useState(false);
+  const [input, setInput] = useState("");
+
+  const frauncesMedItalic = fontsLoaded
+    ? { fontFamily: FONT_FAMILIES.frauncesMediumItalic }
+    : {};
+  const frauncesRegItalic = fontsLoaded
+    ? { fontFamily: FONT_FAMILIES.frauncesRegularItalic }
+    : {};
+
+  const submit = () => {
+    const text = input.trim();
+    if (!text) return;
+    setInput("");
+    setShowSheet(false);
+    onTypeInsteadSubmit(text);
+  };
+
+  return (
+    <View style={styles.wrap}>
+      {/* ── Text content ─────────────────────────────────── */}
+      <View style={styles.textBlock}>
+        <Text style={styles.eyebrow}>— COULDN'T HEAR YOU</Text>
+        <Text style={[styles.headline, frauncesMedItalic]}>
+          Try again, a little louder.
+        </Text>
+        <Text style={styles.body}>
+          Background noise, or your mic drifted. Hold the button and speak
+          directly toward your phone.
+        </Text>
+      </View>
+
+      {/* ── Action buttons ───────────────────────────────── */}
+      <View style={styles.buttons}>
+        <Pressable style={styles.primaryBtn} onPress={onTryAgain}>
+          <Text style={styles.primaryBtnText}>TRY AGAIN</Text>
+        </Pressable>
+        <Pressable style={styles.secondaryBtn} onPress={() => setShowSheet(true)}>
+          <Text style={styles.secondaryBtnText}>TYPE INSTEAD</Text>
+        </Pressable>
+      </View>
+
+      {/* ── Type Instead bottom sheet ─────────────────────── */}
+      <Modal
+        visible={showSheet}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowSheet(false)}
+      >
+        <KeyboardAvoidingView
+          style={styles.sheetOuter}
+          behavior={Platform.OS === "ios" ? "padding" : "height"}
+        >
+          <Pressable style={StyleSheet.absoluteFillObject} onPress={() => setShowSheet(false)} />
+          <View style={styles.sheetPanel}>
+            <Text style={styles.sheetEyebrow}>WHAT DID YOU WANT TO SAY?</Text>
+            <TextInput
+              style={[styles.sheetInput, frauncesRegItalic]}
+              value={input}
+              onChangeText={setInput}
+              placeholder="e.g. How do I order coffee?"
+              placeholderTextColor={TOKENS.inkFaint}
+              autoFocus
+              returnKeyType="send"
+              onSubmitEditing={submit}
+            />
+            <Pressable
+              style={[styles.sheetSubmitBtn, !input.trim() && styles.sheetSubmitBtnDisabled]}
+              onPress={submit}
+              disabled={!input.trim()}
+            >
+              <Text style={styles.sheetSubmitText}>TRANSLATE →</Text>
+            </Pressable>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+    </View>
+  );
+};
+
+const MONO = Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" });
+
+const styles = StyleSheet.create({
+  wrap: {
+    flex: 1,
+    paddingHorizontal: 28,
+    paddingBottom: 36,
+    justifyContent: "space-between",
+  },
+  textBlock: {
+    flex: 1,
+    justifyContent: "center",
+    paddingBottom: 20,
+  },
+  eyebrow: {
+    fontFamily: MONO,
+    fontSize: 11,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: "#7A2D1E",
+    marginBottom: 18,
+  },
+  headline: {
+    fontSize: 30,
+    lineHeight: 36,
+    fontStyle: "italic",
+    color: TOKENS.ink,
+    marginBottom: 16,
+  },
+  body: {
+    fontSize: 14,
+    lineHeight: 22,
+    color: TOKENS.inkSoft,
+  },
+  buttons: {
+    gap: 10,
+  },
+  primaryBtn: {
+    backgroundColor: TOKENS.ink,
+    borderRadius: 2,
+    paddingVertical: 15,
+    alignItems: "center",
+  },
+  primaryBtnText: {
+    fontFamily: MONO,
+    fontSize: 12,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: "#FFFFFF",
+  },
+  secondaryBtn: {
+    borderRadius: 2,
+    borderWidth: 1.5,
+    borderColor: TOKENS.ink,
+    paddingVertical: 15,
+    alignItems: "center",
+  },
+  secondaryBtnText: {
+    fontFamily: MONO,
+    fontSize: 12,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: TOKENS.ink,
+  },
+  // ── Sheet ────────────────────────────────────────────────────
+  sheetOuter: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  sheetPanel: {
+    backgroundColor: TOKENS.bgCard,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingHorizontal: 24,
+    paddingTop: 24,
+    paddingBottom: Platform.OS === "ios" ? 44 : 28,
+    shadowColor: "#000",
+    shadowOpacity: 0.14,
+    shadowRadius: 20,
+    shadowOffset: { width: 0, height: -4 },
+    elevation: 10,
+  },
+  sheetEyebrow: {
+    fontFamily: MONO,
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: TOKENS.inkFaint,
+    marginBottom: 16,
+  },
+  sheetInput: {
+    fontSize: 20,
+    fontStyle: "italic",
+    color: TOKENS.ink,
+    borderBottomWidth: 1.5,
+    borderBottomColor: TOKENS.ruleStrong,
+    paddingVertical: 10,
+    marginBottom: 20,
+  },
+  sheetSubmitBtn: {
+    backgroundColor: TOKENS.ink,
+    borderRadius: 2,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+  sheetSubmitBtnDisabled: {
+    opacity: 0.35,
+  },
+  sheetSubmitText: {
+    fontFamily: MONO,
+    fontSize: 12,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: "#FFFFFF",
+  },
+});
+
+export default CantHearCard;

--- a/mobile/src/components/EntryRow.tsx
+++ b/mobile/src/components/EntryRow.tsx
@@ -1,0 +1,159 @@
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
+
+import { FONT_FAMILIES, TOKENS, toneColor } from "../styles/tokens";
+import type { HistoryEntry } from "../types/history";
+
+type EntryRowProps = {
+  entry: HistoryEntry;
+  showGloss?: boolean;
+  showTime?: boolean;
+  fontsLoaded: boolean;
+  isSaved: boolean;
+  onPlay: () => void;
+  onToggleSave: () => void;
+};
+
+const formatTime = (timestamp: number): string =>
+  new Date(timestamp).toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+
+const EntryRow = ({
+  entry,
+  showGloss = false,
+  showTime = true,
+  fontsLoaded,
+  isSaved,
+  onPlay,
+  onToggleSave,
+}: EntryRowProps) => {
+  const frauncesItalic = fontsLoaded
+    ? { fontFamily: FONT_FAMILIES.frauncesMediumItalic }
+    : {};
+  const notoSerif = fontsLoaded
+    ? { fontFamily: FONT_FAMILIES.notoSerifMedium }
+    : {};
+  const spaceGrotesk = fontsLoaded
+    ? { fontFamily: FONT_FAMILIES.spaceGroteskMedium }
+    : {};
+
+  const syllables = entry.pinyin.trim().split(/\s+/);
+  const hasAudio = Boolean(entry.audioUrl);
+
+  return (
+    <View style={styles.row}>
+      {/* ── Left content ────────────────────────────────── */}
+      <View style={styles.content}>
+        {showTime ? (
+          <Text style={styles.time}>{formatTime(entry.timestamp)}</Text>
+        ) : null}
+        {entry.transcript ? (
+          <Text style={[styles.query, frauncesItalic]} numberOfLines={2}>
+            "{entry.transcript}"
+          </Text>
+        ) : null}
+        <Text style={[styles.chinese, notoSerif]}>{entry.chinese}</Text>
+        <View style={styles.pinyinRow}>
+          {syllables.map((s, i) => (
+            <Text key={i} style={[styles.pinyinSyllable, spaceGrotesk, { color: toneColor(s) }]}>
+              {s}
+            </Text>
+          ))}
+        </View>
+        {showGloss && entry.english ? (
+          <Text style={[styles.gloss, frauncesItalic]} numberOfLines={2}>
+            "{entry.english}"
+          </Text>
+        ) : null}
+      </View>
+
+      {/* ── Right actions ────────────────────────────────── */}
+      <View style={styles.actions}>
+        <Pressable
+          onPress={onPlay}
+          style={[styles.actionBtn, !hasAudio && styles.actionBtnDisabled]}
+          disabled={!hasAudio}
+        >
+          <Text style={[styles.actionIcon, !hasAudio && styles.actionIconDisabled]}>▶</Text>
+        </Pressable>
+        <Pressable onPress={onToggleSave} style={styles.actionBtn}>
+          <Text style={[styles.actionIcon, isSaved && styles.actionIconSaved]}>✦</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    paddingVertical: 14,
+    paddingHorizontal: 20,
+  },
+  content: {
+    flex: 1,
+    marginRight: 14,
+  },
+  time: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 10,
+    letterSpacing: 1.2,
+    color: TOKENS.inkFaint,
+    marginBottom: 5,
+  },
+  query: {
+    fontSize: 15,
+    fontStyle: "italic",
+    lineHeight: 20,
+    color: TOKENS.inkSoft,
+    marginBottom: 6,
+  },
+  chinese: {
+    fontSize: 30,
+    lineHeight: 36,
+    color: TOKENS.ink,
+    marginBottom: 5,
+  },
+  pinyinRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 3,
+  },
+  pinyinSyllable: {
+    fontSize: 13,
+    fontWeight: "500",
+  },
+  gloss: {
+    marginTop: 6,
+    fontSize: 14,
+    fontStyle: "italic",
+    lineHeight: 19,
+    color: TOKENS.inkSoft,
+  },
+  actions: {
+    alignItems: "center",
+    gap: 14,
+    paddingTop: 2,
+  },
+  actionBtn: {
+    padding: 4,
+  },
+  actionBtnDisabled: {
+    opacity: 0.3,
+  },
+  actionIcon: {
+    fontSize: 16,
+    color: TOKENS.inkFaint,
+  },
+  actionIconSaved: {
+    color: TOKENS.accent,
+  },
+  actionIconDisabled: {
+    color: TOKENS.inkFaint,
+  },
+});
+
+export default EntryRow;

--- a/mobile/src/components/HistoryScreen.tsx
+++ b/mobile/src/components/HistoryScreen.tsx
@@ -1,0 +1,139 @@
+import { Platform, ScrollView, StyleSheet, Text, View } from "react-native";
+
+import { useHistoryStore, useSavedStore } from "../store/historyStore";
+import { TOKENS } from "../styles/tokens";
+import type { HistoryEntry } from "../types/history";
+import { playSoundUrl } from "../utils/audio";
+import EntryRow from "./EntryRow";
+
+type DayGroup = { label: string; entries: HistoryEntry[] };
+
+const groupByDay = (entries: HistoryEntry[]): DayGroup[] => {
+  const map = new Map<string, HistoryEntry[]>();
+  for (const entry of entries) {
+    const key = new Date(entry.timestamp).toDateString();
+    map.set(key, [...(map.get(key) ?? []), entry]);
+  }
+
+  const today = new Date().toDateString();
+  const yesterday = new Date(Date.now() - 86400000).toDateString();
+
+  return Array.from(map.entries()).map(([key, dayEntries]) => {
+    const d = new Date(dayEntries[0].timestamp);
+    const month = d.toLocaleString("en-US", { month: "long" }).toUpperCase();
+    const day = d.getDate();
+    const n = dayEntries.length;
+    const word = n === 1 ? "PHRASE" : "PHRASES";
+    const prefix = key === today ? "TODAY" : key === yesterday ? "YESTERDAY" : null;
+    const label = prefix
+      ? `${prefix} · ${month} ${day} · ${n} ${word}`
+      : `${month} ${day} · ${n} ${word}`;
+    return { label, entries: dayEntries };
+  });
+};
+
+type Props = { fontsLoaded: boolean };
+
+const HistoryScreen = ({ fontsLoaded }: Props) => {
+  const entries = useHistoryStore((s) => s.entries);
+  const { save, unsave, isSaved } = useSavedStore();
+
+  if (entries.length === 0) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyLabel}>NO HISTORY YET</Text>
+        <Text style={styles.emptyHint}>Hold the mic button and speak to get started.</Text>
+      </View>
+    );
+  }
+
+  const groups = groupByDay(entries);
+
+  return (
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={styles.content}
+      showsVerticalScrollIndicator={false}
+    >
+      {groups.map((group) => (
+        <View key={group.label}>
+          {/* Day eyebrow */}
+          <Text style={styles.dayEyebrow}>{group.label}</Text>
+
+          {group.entries.map((entry, i) => (
+            <View key={entry.id}>
+              <EntryRow
+                entry={entry}
+                showTime
+                fontsLoaded={fontsLoaded}
+                isSaved={isSaved(entry.id)}
+                onPlay={() => {
+                  if (entry.audioUrl) void playSoundUrl(entry.audioUrl);
+                }}
+                onToggleSave={() => {
+                  isSaved(entry.id) ? unsave(entry.id) : save(entry);
+                }}
+              />
+              {i < group.entries.length - 1 ? <View style={styles.rule} /> : null}
+            </View>
+          ))}
+
+          {/* Thicker rule between day groups */}
+          <View style={styles.dayRule} />
+        </View>
+      ))}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  scroll: {
+    flex: 1,
+  },
+  content: {
+    paddingBottom: 40,
+  },
+  empty: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 36,
+  },
+  emptyLabel: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 10,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: TOKENS.inkFaint,
+    marginBottom: 10,
+  },
+  emptyHint: {
+    fontSize: 14,
+    color: TOKENS.inkFaint,
+    textAlign: "center",
+    lineHeight: 20,
+  },
+  dayEyebrow: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: TOKENS.inkFaint,
+    paddingHorizontal: 20,
+    paddingTop: 22,
+    paddingBottom: 10,
+  },
+  rule: {
+    height: 1,
+    backgroundColor: TOKENS.rule,
+    marginHorizontal: 20,
+  },
+  dayRule: {
+    height: 1,
+    backgroundColor: TOKENS.ruleStrong,
+    marginHorizontal: 0,
+    marginTop: 4,
+  },
+});
+
+export default HistoryScreen;

--- a/mobile/src/components/SavedScreen.tsx
+++ b/mobile/src/components/SavedScreen.tsx
@@ -1,0 +1,119 @@
+import { Platform, ScrollView, StyleSheet, Text, View } from "react-native";
+
+import { useSavedStore } from "../store/historyStore";
+import { TOKENS } from "../styles/tokens";
+import type { SavedEntry } from "../types/history";
+import { playSoundUrl } from "../utils/audio";
+import EntryRow from "./EntryRow";
+
+type TagGroup = { tag: string; entries: SavedEntry[] };
+
+const groupByTag = (entries: SavedEntry[]): TagGroup[] => {
+  const map = new Map<string, SavedEntry[]>();
+  for (const entry of entries) {
+    map.set(entry.tag, [...(map.get(entry.tag) ?? []), entry]);
+  }
+  return Array.from(map.entries()).map(([tag, tagEntries]) => ({ tag, entries: tagEntries }));
+};
+
+type Props = { fontsLoaded: boolean };
+
+const SavedScreen = ({ fontsLoaded }: Props) => {
+  const { entries, unsave } = useSavedStore();
+
+  if (entries.length === 0) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyLabel}>NOTHING SAVED YET</Text>
+        <Text style={styles.emptyHint}>Tap ✦ on any phrase in History to save it here.</Text>
+      </View>
+    );
+  }
+
+  const groups = groupByTag(entries);
+
+  return (
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={styles.content}
+      showsVerticalScrollIndicator={false}
+    >
+      {groups.map((group) => (
+        <View key={group.tag}>
+          {/* Tag eyebrow  — DINING */}
+          <Text style={styles.tagEyebrow}>— {group.tag}</Text>
+
+          {group.entries.map((entry, i) => (
+            <View key={entry.id}>
+              <EntryRow
+                entry={entry}
+                showGloss
+                showTime={false}
+                fontsLoaded={fontsLoaded}
+                isSaved
+                onPlay={() => {
+                  if (entry.audioUrl) void playSoundUrl(entry.audioUrl);
+                }}
+                onToggleSave={() => unsave(entry.id)}
+              />
+              {i < group.entries.length - 1 ? <View style={styles.rule} /> : null}
+            </View>
+          ))}
+
+          <View style={styles.tagRule} />
+        </View>
+      ))}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  scroll: {
+    flex: 1,
+  },
+  content: {
+    paddingBottom: 40,
+  },
+  empty: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 36,
+  },
+  emptyLabel: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 10,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: TOKENS.inkFaint,
+    marginBottom: 10,
+  },
+  emptyHint: {
+    fontSize: 14,
+    color: TOKENS.inkFaint,
+    textAlign: "center",
+    lineHeight: 20,
+  },
+  tagEyebrow: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 11,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: TOKENS.accent,
+    paddingHorizontal: 20,
+    paddingTop: 22,
+    paddingBottom: 10,
+  },
+  rule: {
+    height: 1,
+    backgroundColor: TOKENS.rule,
+    marginHorizontal: 20,
+  },
+  tagRule: {
+    height: 1,
+    backgroundColor: TOKENS.ruleStrong,
+    marginTop: 4,
+  },
+});
+
+export default SavedScreen;

--- a/mobile/src/components/VoiceStage.tsx
+++ b/mobile/src/components/VoiceStage.tsx
@@ -2,11 +2,30 @@ import { useEffect, useRef, useState } from "react";
 import {
   Animated,
   Easing,
+  Platform,
   Pressable,
   StyleSheet,
   Text,
   View,
 } from "react-native";
+
+const MicIcon = ({ color = "white" }: { color?: string }) => (
+  <View style={{ alignItems: "center" }}>
+    <View style={{ width: 11, height: 18, borderRadius: 5.5, backgroundColor: color }} />
+    <View style={{
+      width: 20,
+      height: 9,
+      borderLeftWidth: 2,
+      borderRightWidth: 2,
+      borderBottomWidth: 2,
+      borderColor: color,
+      borderBottomLeftRadius: 10,
+      borderBottomRightRadius: 10,
+      marginTop: -2,
+    }} />
+    <View style={{ width: 11, height: 2, backgroundColor: color, marginTop: 2 }} />
+  </View>
+);
 
 export type VoiceStageState =
   | "idle"
@@ -55,7 +74,7 @@ const STATE_LABEL_ZH: Record<VoiceStageState, string> = {
   complete:   "完成",
 };
 
-const BUTTON_SIZE = 120;
+const BUTTON_SIZE = 76;
 
 const VoiceStage = ({
   state,
@@ -167,14 +186,20 @@ const VoiceStage = ({
         <Pressable
           style={[
             styles.button,
-            { backgroundColor: isListening ? bgPress : bg, borderColor: border },
+            state === "idle"
+              ? styles.buttonIdle
+              : { backgroundColor: isListening ? bgPress : bg, borderColor: border },
             disabled && styles.buttonDisabled,
           ]}
           onPressIn={onPressIn}
           onPressOut={onPressOut}
           disabled={disabled}
         >
-          <Text style={styles.icon}>{STATE_ICON[state]}</Text>
+          {state === "idle" ? (
+            <MicIcon color="white" />
+          ) : (
+            <Text style={styles.icon}>{STATE_ICON[state]}</Text>
+          )}
         </Pressable>
       </Animated.View>
       {isProcessing ? (
@@ -183,6 +208,8 @@ const VoiceStage = ({
         >
           Thinking...
         </Animated.Text>
+      ) : state === "idle" ? (
+        <Text style={styles.idleLabel}>Hold · Speak · Release</Text>
       ) : (
         <Text style={[styles.label, { color: bg }]}>{STATE_LABEL[state]}</Text>
       )}
@@ -217,14 +244,29 @@ const styles = StyleSheet.create({
   buttonDisabled: {
     opacity: 0.4,
   },
+  buttonIdle: {
+    backgroundColor: "#15110D",
+    borderWidth: 0,
+    shadowOpacity: 0.18,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 4 },
+  },
   icon: {
-    fontSize: 36,
+    fontSize: 28,
   },
   label: {
     marginTop: 14,
     fontSize: 15,
     fontWeight: "600",
     letterSpacing: 0.2,
+  },
+  idleLabel: {
+    marginTop: 12,
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: "#8F8578",
   },
   processingLabel: {
     minWidth: 100,

--- a/mobile/src/components/VoiceStage.tsx
+++ b/mobile/src/components/VoiceStage.tsx
@@ -107,16 +107,27 @@ const VoiceStage = ({
   useEffect(() => {
     if (isListening) {
       setHasEnoughRecording(false);
-      Animated.timing(ringAnim, {
-        toValue: 1,
-        duration: 2000,
-        easing: Easing.out(Easing.cubic),
-        useNativeDriver: true,
-      }).start();
+      const loop = Animated.loop(
+        Animated.sequence([
+          Animated.timing(ringAnim, {
+            toValue: 1,
+            duration: 1600,
+            easing: Easing.out(Easing.quad),
+            useNativeDriver: true,
+          }),
+          Animated.timing(ringAnim, {
+            toValue: 0,
+            duration: 0,
+            useNativeDriver: true,
+          }),
+        ])
+      );
+      loop.start();
       enoughTimerRef.current = setTimeout(() => {
         setHasEnoughRecording(true);
       }, 2000);
       return () => {
+        loop.stop();
         if (enoughTimerRef.current) {
           clearTimeout(enoughTimerRef.current);
           enoughTimerRef.current = null;
@@ -161,11 +172,11 @@ const VoiceStage = ({
 
   const ringScale = ringAnim.interpolate({
     inputRange: [0, 1],
-    outputRange: [1, 1.9],
+    outputRange: [1, 2.5],
   });
   const ringOpacity = ringAnim.interpolate({
-    inputRange: [0, 0.8, 1],
-    outputRange: [0.55, 0.45, 0.35],
+    inputRange: [0, 0.5, 1],
+    outputRange: [0.85, 0.35, 0],
   });
 
   return (
@@ -173,9 +184,8 @@ const VoiceStage = ({
       {isListening ? (
         <Animated.View
           style={[
-            styles.ring,
+            styles.pulseRing,
             {
-              backgroundColor: hasEnoughRecording ? "#22C55E" : ring,
               transform: [{ scale: ringScale }],
               opacity: ringOpacity,
             },
@@ -186,9 +196,9 @@ const VoiceStage = ({
         <Pressable
           style={[
             styles.button,
-            state === "idle"
-              ? styles.buttonIdle
-              : { backgroundColor: isListening ? bgPress : bg, borderColor: border },
+            state === "idle" && styles.buttonIdle,
+            isListening && styles.buttonListening,
+            !state.match(/^idle|listening$/) && { backgroundColor: bg, borderColor: border },
             disabled && styles.buttonDisabled,
           ]}
           onPressIn={onPressIn}
@@ -222,11 +232,14 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  ring: {
+  pulseRing: {
     position: "absolute",
     width: BUTTON_SIZE,
     height: BUTTON_SIZE,
     borderRadius: BUTTON_SIZE / 2,
+    borderWidth: 1.5,
+    borderColor: "#1D4D3B",
+    backgroundColor: "transparent",
   },
   button: {
     width: BUTTON_SIZE,
@@ -250,6 +263,10 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.18,
     shadowRadius: 10,
     shadowOffset: { width: 0, height: 4 },
+  },
+  buttonListening: {
+    backgroundColor: "#1D4D3B",
+    borderWidth: 0,
   },
   icon: {
     fontSize: 28,

--- a/mobile/src/store/historyStore.ts
+++ b/mobile/src/store/historyStore.ts
@@ -1,0 +1,54 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+import type { HistoryEntry, SavedEntry } from "../types/history";
+
+type HistoryState = {
+  entries: HistoryEntry[];
+  addEntry: (entry: HistoryEntry) => void;
+  clear: () => void;
+};
+
+type SavedState = {
+  entries: SavedEntry[];
+  save: (entry: HistoryEntry, tag?: string) => void;
+  unsave: (id: string) => void;
+  isSaved: (id: string) => boolean;
+};
+
+export const useHistoryStore = create<HistoryState>()(
+  persist(
+    (set) => ({
+      entries: [],
+      addEntry: (entry) =>
+        set((s) => ({ entries: [entry, ...s.entries].slice(0, 500) })),
+      clear: () => set({ entries: [] }),
+    }),
+    {
+      name: "voice-history-v1",
+      storage: createJSONStorage(() => AsyncStorage),
+    }
+  )
+);
+
+export const useSavedStore = create<SavedState>()(
+  persist(
+    (set, get) => ({
+      entries: [],
+      save: (entry, tag = "GENERAL") =>
+        set((s) => ({
+          entries: s.entries.some((e) => e.id === entry.id)
+            ? s.entries
+            : [{ ...entry, tag, savedAt: Date.now() }, ...s.entries],
+        })),
+      unsave: (id) =>
+        set((s) => ({ entries: s.entries.filter((e) => e.id !== id) })),
+      isSaved: (id) => get().entries.some((e) => e.id === id),
+    }),
+    {
+      name: "voice-saved-v1",
+      storage: createJSONStorage(() => AsyncStorage),
+    }
+  )
+);

--- a/mobile/src/store/uiStore.ts
+++ b/mobile/src/store/uiStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+export type ActiveTab = "SPEAK" | "HISTORY" | "SAVED";
+
+type UIState = {
+  activeTab: ActiveTab;
+  setActiveTab: (tab: ActiveTab) => void;
+};
+
+export const useUIStore = create<UIState>((set) => ({
+  activeTab: "SPEAK",
+  setActiveTab: (tab) => set({ activeTab: tab }),
+}));

--- a/mobile/src/styles/tokens.ts
+++ b/mobile/src/styles/tokens.ts
@@ -20,6 +20,17 @@ export const TOKENS = {
 export const getToneColor = (tone: 1 | 2 | 3 | 4 | 5): string =>
   TOKENS.tones[`t${tone}` as keyof typeof TOKENS.tones];
 
+export const detectTone = (syllable: string): 1 | 2 | 3 | 4 | 5 => {
+  if (/[āēīōūǖĀĒĪŌŪǕ]/.test(syllable)) return 1;
+  if (/[áéíóúǘÁÉÍÓÚǗ]/.test(syllable)) return 2;
+  if (/[ǎěǐǒǔǚǍĚǏǑǓǙ]/.test(syllable)) return 3;
+  if (/[àèìòùǜÀÈÌÒÙǛ]/.test(syllable)) return 4;
+  return 5;
+};
+
+export const toneColor = (syllable: string): string =>
+  getToneColor(detectTone(syllable));
+
 export const FONT_FAMILIES = {
   frauncesRegular: "Fraunces_400Regular",
   frauncesRegularItalic: "Fraunces_400Regular_Italic",
@@ -31,3 +42,4 @@ export const FONT_FAMILIES = {
   spaceGroteskSemiBold: "SpaceGrotesk_600SemiBold",
   spaceGroteskBold: "SpaceGrotesk_700Bold",
 } as const;
+

--- a/mobile/src/styles/tokens.ts
+++ b/mobile/src/styles/tokens.ts
@@ -1,0 +1,33 @@
+export const TOKENS = {
+  bg: "#F5F2EC",
+  bgCard: "#FFFDF8",
+  ink: "#15110D",
+  inkSoft: "#544B40",
+  inkFaint: "#8F8578",
+  accent: "#1D4D3B",
+  accentSoft: "#E3EADD",
+  rule: "rgba(21,17,13,0.12)",
+  ruleStrong: "rgba(21,17,13,0.22)",
+  tones: {
+    t1: "#B44637",
+    t2: "#3E7A3C",
+    t3: "#2E5E8C",
+    t4: "#7A2D1E",
+    t5: "#8F8578",
+  },
+} as const;
+
+export const getToneColor = (tone: 1 | 2 | 3 | 4 | 5): string =>
+  TOKENS.tones[`t${tone}` as keyof typeof TOKENS.tones];
+
+export const FONT_FAMILIES = {
+  frauncesRegular: "Fraunces_400Regular",
+  frauncesRegularItalic: "Fraunces_400Regular_Italic",
+  frauncesMedium: "Fraunces_500Medium",
+  frauncesMediumItalic: "Fraunces_500Medium_Italic",
+  notoSerifRegular: "NotoSerifSC_400Regular",
+  notoSerifMedium: "NotoSerifSC_500Medium",
+  spaceGroteskMedium: "SpaceGrotesk_500Medium",
+  spaceGroteskSemiBold: "SpaceGrotesk_600SemiBold",
+  spaceGroteskBold: "SpaceGrotesk_700Bold",
+} as const;

--- a/mobile/src/types/history.ts
+++ b/mobile/src/types/history.ts
@@ -1,0 +1,15 @@
+export type HistoryEntry = {
+  id: string;
+  timestamp: number;
+  transcript: string;
+  chinese: string;
+  pinyin: string;
+  english: string;
+  notes: string[];
+  audioUrl?: string | null;
+};
+
+export type SavedEntry = HistoryEntry & {
+  tag: string;
+  savedAt: number;
+};

--- a/mobile/src/utils/audio.ts
+++ b/mobile/src/utils/audio.ts
@@ -1,0 +1,16 @@
+import { Audio } from "expo-av";
+
+export const playSoundUrl = async (url: string): Promise<void> => {
+  try {
+    await Audio.setAudioModeAsync({ allowsRecordingIOS: false, playsInSilentModeIOS: true });
+    const { sound } = await Audio.Sound.createAsync({ uri: url });
+    await sound.playAsync();
+    sound.setOnPlaybackStatusUpdate((status) => {
+      if (status.isLoaded && status.didJustFinish) {
+        void sound.unloadAsync();
+      }
+    });
+  } catch (e) {
+    console.error("playSoundUrl error:", e);
+  }
+};


### PR DESCRIPTION
## Summary
This PR introduces a major UI overhaul with tabbed navigation (SPEAK, HISTORY, SAVED), persistent history and saved phrases management, improved visual feedback during recording/processing, and custom typography support via Google Fonts.

## Key Changes

### Navigation & Screens
- Added three-tab navigation system (SPEAK, HISTORY, SAVED) with persistent state via `useUIStore`
- Created `HistoryScreen` component displaying voice exchanges grouped by day with timestamps
- Created `SavedScreen` component for managing saved phrases organized by tag
- Added `CantHearCard` component with "Try Again" and "Type Instead" options for low-confidence STT results
- Implemented bottom sheet modal for typing text queries when speech recognition fails

### State Management
- New `useHistoryStore` (Zustand + AsyncStorage) for persisting up to 500 voice exchanges
- New `useSavedStore` for managing saved entries with custom tags
- New `useUIStore` for tracking active tab
- Added `HistoryEntry` and `SavedEntry` types for type-safe history management

### Visual Enhancements
- Integrated Google Fonts: Fraunces (serif, italic), Noto Serif SC (Chinese), Space Grotesk (monospace)
- Created `ProcessingView` component with shimmer skeleton loaders and bouncing dots animation
- Created `ListeningView` component with 48-bar waveform visualization synced to microphone metering
- Created `ResponseView` component displaying tone-colored pinyin, morpheme breakdown, and pronunciation scoring
- Added `ShimmerSkeleton` component for loading states with animated highlight effect
- Redesigned header with new wordmark styling and hamburger menu button
- Refactored language toggle from bordered pills to arrow-separated text

### Recording & Audio
- Added real-time metering level tracking during recording
- Implemented live transcript display with blinking caret animation
- Added `handleReplayAudio` function supporting normal and 0.65x slow playback
- Added `handleTypeInsteadSubmit` for text-based queries when speech fails
- Enhanced `SpeechTurnResponse` type with `score` and `transcript_confidence` fields

### Utility Components
- Created `EntryRow` component for displaying history/saved entries with play and save actions
- Created `playSoundUrl` utility for audio playback from URLs
- Added tone detection and color mapping utilities (`detectTone`, `toneColor`, `getToneColor`)
- Added `buildBreakdown` function for morpheme-level pinyin/hanzi pairing

### Styling & Design
- New `tokens.ts` with color palette, tone colors, and font family constants
- Comprehensive stylesheet updates for new components and animations
- Added monospace font fallbacks for eyebrow labels and UI text
- Implemented responsive layout for bottom sheet and modal interactions

### Dependencies
- Added `@expo-google-fonts/fraunces`, `@expo-google-fonts/noto-serif-sc`, `@expo-google-fonts/space-grotesk`

## Notable Implementation Details
- History entries are limited to 500 most recent exchanges to manage storage
- Pronunciation scores only displayed when API returns a score value
- Low-confidence STT results (< 0.4 confidence or < 2 chars) trigger "Can't Hear" card instead of error toast
- Waveform bars use sine wave envelope for natural center-heavy visualization
- Tone colors applied dynamically to pinyin based on diacritical marks
- All animations use native driver for performance

https://claude.ai/code/session_01HLuyjh7NfoNKsHKiThcRvC