### PR TITLE
V2 heuristic audit — all 10 UX issues resolved (#58–#67)

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -744,7 +744,6 @@ export default function App() {
   const [selectedScenario, setSelectedScenario] = useState<PracticeScenario | null>(null);
   const [selectedVoice, setSelectedVoice] = useState<VoiceOption>("warm");
   const [showDrawer, setShowDrawer] = useState(false);
-  const [pendingQuery, setPendingQuery] = useState<string | null>(null);
   const [liveTranscript, setLiveTranscript] = useState("");
   const [meteringLevel, setMeteringLevel] = useState(-160);
   const [processingTranscript, setProcessingTranscript] = useState("");
@@ -1063,6 +1062,7 @@ export default function App() {
   };
 
   const handleTypeInsteadSubmit = async (text: string) => {
+    if (isRecording || isUploadingVoice) return;
     setShowCantHear(false);
     setIsUploadingVoice(true);
     setProcessingTranscript(text);
@@ -1832,13 +1832,12 @@ export default function App() {
                 <Pressable
                   key={s}
                   style={styles.suggestionRow}
-                  onPress={() => setPendingQuery(pendingQuery === s ? null : s)}
+                  onPress={() => { void handleTypeInsteadSubmit(s); }}
                 >
                   <Text
                     style={[
                       styles.suggestionText,
                       fontsLoaded ? { fontFamily: "Fraunces_500Medium_Italic" } : {},
-                      pendingQuery === s && styles.suggestionTextActive,
                     ]}
                   >
                     "{s}"
@@ -1848,21 +1847,6 @@ export default function App() {
               ))}
             </View>
           )}
-
-          {/* Pending query prompt — shown when a suggestion is tapped */}
-          {!isRecording && !voiceTurn && pendingQuery ? (
-            <View style={styles.pendingQueryWrap}>
-              <Text style={styles.pendingQueryLabel}>SAY SOMETHING LIKE</Text>
-              <Text
-                style={[
-                  styles.pendingQueryText,
-                  fontsLoaded ? { fontFamily: "Fraunces_500Medium_Italic" } : {},
-                ]}
-              >
-                "{pendingQuery}"
-              </Text>
-            </View>
-          ) : null}
 
           <Animated.View
             style={[
@@ -2428,31 +2412,10 @@ const styles = StyleSheet.create({
     color: "#15110D",
     flex: 1,
   },
-  suggestionTextActive: {
-    color: "#1D4D3B",
-  },
   suggestionChevron: {
     fontSize: 18,
     color: "#8F8578",
     marginLeft: 8,
-  },
-  pendingQueryWrap: {
-    alignItems: "center",
-    paddingVertical: 10,
-  },
-  pendingQueryLabel: {
-    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
-    fontSize: 9,
-    letterSpacing: 1.6,
-    textTransform: "uppercase",
-    color: "#8F8578",
-    marginBottom: 4,
-  },
-  pendingQueryText: {
-    fontSize: 15,
-    fontStyle: "italic",
-    color: "#1D4D3B",
-    textAlign: "center",
   },
   dailyPhrase: {
     alignItems: "center",

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -17,9 +17,11 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
+  AppState,
   Animated,
   Easing,
   KeyboardAvoidingView,
+  Linking,
   Modal,
   Platform,
   Pressable,
@@ -37,6 +39,7 @@ import { TOKENS, getToneColor, FONT_FAMILIES, detectTone, toneColor } from "./sr
 import ApiBlockedScreen from "./src/components/ApiBlockedScreen";
 import AuthScreen from "./src/components/AuthScreen";
 import CantHearCard from "./src/components/CantHearCard";
+import MicDeniedCard from "./src/components/MicDeniedCard";
 import HistoryScreen from "./src/components/HistoryScreen";
 import LockScreen from "./src/components/LockScreen";
 import SavedScreen from "./src/components/SavedScreen";
@@ -1441,6 +1444,17 @@ export default function App() {
     };
   }, []);
 
+  // Re-check mic permission when the user returns from the system Settings app.
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", async (nextState) => {
+      if (nextState === "active" && micPermission === "denied") {
+        const result = await Audio.getPermissionsAsync();
+        if (result.granted) setMicPermission("granted");
+      }
+    });
+    return () => sub.remove();
+  }, [micPermission]);
+
   useEffect(() => {
     ambientDriftA.setValue(0);
     ambientDriftB.setValue(0);
@@ -1667,13 +1681,9 @@ export default function App() {
           </View>
         </Animated.View>
 
-        {error || voiceError || micPermission === "denied" ? (
+        {error || voiceError ? (
           <View style={styles.errorBanner}>
-            <Text style={styles.errorText}>
-              {micPermission === "denied"
-                ? "Microphone access is disabled. Enable it in system settings."
-                : voiceError ?? error}
-            </Text>
+            <Text style={styles.errorText}>{voiceError ?? error}</Text>
           </View>
         ) : null}
 
@@ -1682,14 +1692,20 @@ export default function App() {
         ) : activeTab === "SAVED" ? (
           <SavedScreen fontsLoaded={!!fontsLoaded} />
         ) : null}
-        {activeTab === "SPEAK" && showCantHear ? (
+        {activeTab === "SPEAK" && micPermission === "denied" ? (
+          <MicDeniedCard
+            fontsLoaded={!!fontsLoaded}
+            onTypeInsteadSubmit={(text) => { void handleTypeInsteadSubmit(text); }}
+          />
+        ) : null}
+        {activeTab === "SPEAK" && micPermission !== "denied" && showCantHear ? (
           <CantHearCard
             fontsLoaded={!!fontsLoaded}
             onTryAgain={() => setShowCantHear(false)}
             onTypeInsteadSubmit={(text) => { void handleTypeInsteadSubmit(text); }}
           />
         ) : null}
-        {activeTab === "SPEAK" && !showCantHear ? <View style={styles.centerStage}>
+        {activeTab === "SPEAK" && micPermission !== "denied" && !showCantHear ? <View style={styles.centerStage}>
           <View style={styles.practiceScenarioWrap}>
             <Pressable
               style={[
@@ -1867,7 +1883,7 @@ export default function App() {
               onPressOut={() => {
                 void stopRecording();
               }}
-              disabled={isUploadingVoice || micPermission === "denied"}
+              disabled={isUploadingVoice}
             />
           </Animated.View>
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -439,9 +439,9 @@ const ShimmerSkeleton = ({
 
 // ─── Processing / translating screen ─────────────────────────────────────────
 
-type ProcessingViewProps = { processingTranscript: string; fontsLoaded: boolean };
+type ProcessingViewProps = { processingTranscript: string; fontsLoaded: boolean; onCancel: () => void };
 
-const ProcessingView = ({ processingTranscript, fontsLoaded }: ProcessingViewProps) => {
+const ProcessingView = ({ processingTranscript, fontsLoaded, onCancel }: ProcessingViewProps) => {
   const shimmerAnim = useRef(new Animated.Value(0)).current;
   const dot1 = useRef(new Animated.Value(0)).current;
   const dot2 = useRef(new Animated.Value(0)).current;
@@ -508,6 +508,10 @@ const ProcessingView = ({ processingTranscript, fontsLoaded }: ProcessingViewPro
         <ShimmerSkeleton height={14} shimmerAnim={shimmerAnim} />
         <ShimmerSkeleton height={14} shimmerAnim={shimmerAnim} />
       </View>
+
+      <Pressable onPress={onCancel} style={styles.cancelBtn} hitSlop={12}>
+        <Text style={styles.cancelBtnText}>✕  CANCEL</Text>
+      </Pressable>
     </View>
   );
 };
@@ -762,6 +766,8 @@ export default function App() {
   const recordingRef = useRef<Audio.Recording | null>(null);
   const soundRef = useRef<Audio.Sound | null>(null);
   const completeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const voiceFetchControllerRef = useRef<AbortController | null>(null);
+  const userCancelledRef = useRef(false);
   const responseFade = useRef(new Animated.Value(0)).current;
   const stageTransition = useRef(new Animated.Value(0)).current;
   const ambientDriftA = useRef(new Animated.Value(0)).current;
@@ -1073,12 +1079,16 @@ export default function App() {
       formData.append("voice", selectedVoice);
 
       logApiBaseUrl("Text query");
+      const fetchController = new AbortController();
+      voiceFetchControllerRef.current = fetchController;
       const { response } = await apiFetchWithTimeout(
         "/v1/speech/turn",
         { method: "POST", body: formData },
         90_000,
-        1
+        1,
+        fetchController.signal
       );
+      voiceFetchControllerRef.current = null;
       const raw = await response.text();
       if (!response.ok) throw new Error(`Text query failed ${response.status}: ${raw}`);
 
@@ -1130,8 +1140,14 @@ export default function App() {
       }
     } catch (err) {
       console.error("Type-instead error:", err);
+      if (userCancelledRef.current) {
+        setProcessingTranscript("");
+        return;
+      }
       setVoiceError("Translation failed. Please try again.");
     } finally {
+      userCancelledRef.current = false;
+      voiceFetchControllerRef.current = null;
       setIsUploadingVoice(false);
     }
   };
@@ -1167,6 +1183,11 @@ export default function App() {
       console.error("Replay error:", e);
       setIsPlayingPronunciation(false);
     }
+  };
+
+  const handleCancelTranslation = () => {
+    userCancelledRef.current = true;
+    voiceFetchControllerRef.current?.abort();
   };
 
   const startRecording = async () => {
@@ -1257,6 +1278,8 @@ export default function App() {
 
       logApiBaseUrl("Voice upload");
       const startedAt = Date.now();
+      const fetchController = new AbortController();
+      voiceFetchControllerRef.current = fetchController;
       const { response } = await apiFetchWithTimeout(
         "/v1/speech/turn",
         {
@@ -1264,8 +1287,10 @@ export default function App() {
           body: formData,
         },
         90_000,
-        1
+        1,
+        fetchController.signal
       );
+      voiceFetchControllerRef.current = null;
 
       const durationMs = Date.now() - startedAt;
       const raw = await response.text();
@@ -1340,6 +1365,10 @@ export default function App() {
       }
     } catch (voiceUploadError) {
       console.error("Voice upload error:", voiceUploadError);
+      if (userCancelledRef.current) {
+        setProcessingTranscript("");
+        return;
+      }
       const errMsg =
         voiceUploadError instanceof Error ? voiceUploadError.message : "";
       const isTimeout =
@@ -1355,6 +1384,8 @@ export default function App() {
             : "Voice request failed. Please try again."
       );
     } finally {
+      userCancelledRef.current = false;
+      voiceFetchControllerRef.current = null;
       setIsUploadingVoice(false);
     }
   };
@@ -1751,6 +1782,7 @@ export default function App() {
             <ProcessingView
               processingTranscript={processingTranscript}
               fontsLoaded={!!fontsLoaded}
+              onCancel={handleCancelTranslation}
             />
           ) : voiceTurn ? (
             <Animated.View style={{ opacity: responseFade, alignSelf: "stretch" }}>
@@ -2263,6 +2295,18 @@ const styles = StyleSheet.create({
   },
   skeletonGroup: {
     gap: 10,
+  },
+  cancelBtn: {
+    alignSelf: "center",
+    marginTop: 32,
+    padding: 12,
+  },
+  cancelBtnText: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 11,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: "#8F8578",
   },
   skeletonBar: {
     alignSelf: "stretch",

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1992,7 +1992,7 @@ const styles = StyleSheet.create({
   },
   practiceScenarioButton: {
     borderWidth: 1,
-    borderRadius: 16,
+    borderRadius: TOKENS.buttonRadius,
     paddingHorizontal: 14,
     paddingVertical: 12,
     gap: 4,
@@ -2011,7 +2011,7 @@ const styles = StyleSheet.create({
   },
   practiceScenarioCard: {
     borderWidth: 1,
-    borderRadius: 14,
+    borderRadius: TOKENS.cardRadius,
     paddingHorizontal: 12,
     paddingVertical: 10,
   },
@@ -2027,7 +2027,7 @@ const styles = StyleSheet.create({
   relevantVocabPanel: {
     width: "100%",
     borderWidth: 1,
-    borderRadius: 16,
+    borderRadius: TOKENS.cardRadius,
     paddingHorizontal: 14,
     paddingVertical: 12,
     marginBottom: 14,
@@ -2224,7 +2224,7 @@ const styles = StyleSheet.create({
     backgroundColor: "#FDFAF6",
     marginTop: 88,
     marginRight: 16,
-    borderRadius: 12,
+    borderRadius: TOKENS.cardRadius,
     paddingVertical: 12,
     paddingHorizontal: 16,
     minWidth: 180,
@@ -2455,7 +2455,7 @@ const styles = StyleSheet.create({
   voiceResultCenter: {
     alignItems: "center",
     marginBottom: 48,
-    borderRadius: 20,
+    borderRadius: TOKENS.cardRadius,
     borderWidth: 1,
     paddingHorizontal: 24,
     paddingVertical: 20,
@@ -2495,7 +2495,7 @@ const styles = StyleSheet.create({
   },
   voiceHistoryBubble: {
     borderWidth: 1,
-    borderRadius: 18,
+    borderRadius: TOKENS.cardRadius,
     paddingVertical: 12,
     paddingHorizontal: 14,
   },
@@ -2551,7 +2551,7 @@ const styles = StyleSheet.create({
   },
   onboardingCard: {
     backgroundColor: "#FFF7ED",
-    borderRadius: 20,
+    borderRadius: TOKENS.cardRadius,
     padding: 24,
     width: "100%",
     maxWidth: 420,
@@ -2577,7 +2577,7 @@ const styles = StyleSheet.create({
   onboardingButton: {
     backgroundColor: "#B91C1C",
     paddingVertical: 12,
-    borderRadius: 18,
+    borderRadius: TOKENS.buttonRadius,
     alignItems: "center",
     marginBottom: 12,
   },
@@ -2647,7 +2647,7 @@ const styles = StyleSheet.create({
   resPlayButton: {
     flex: 2,
     backgroundColor: TOKENS.ink,
-    borderRadius: 2,
+    borderRadius: TOKENS.buttonRadius,
     paddingVertical: 12,
     alignItems: "center",
   },
@@ -2663,7 +2663,7 @@ const styles = StyleSheet.create({
   },
   resSlowButton: {
     flex: 1,
-    borderRadius: 2,
+    borderRadius: TOKENS.buttonRadius,
     borderWidth: 1.5,
     borderColor: TOKENS.ink,
     paddingVertical: 12,

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -34,6 +34,7 @@ import {
 
 import { useUIStore } from "./src/store/uiStore";
 import { useHistoryStore, useSavedStore } from "./src/store/historyStore";
+import type { HistoryEntry } from "./src/types/history";
 import { TOKENS, getToneColor, FONT_FAMILIES, detectTone, toneColor } from "./src/styles/tokens";
 
 import ApiBlockedScreen from "./src/components/ApiBlockedScreen";
@@ -629,14 +630,17 @@ type ResponseViewProps = {
   fontsLoaded: boolean;
   onPlayAudio: (slow: boolean) => void;
   isPlaying: boolean;
+  historyEntry: HistoryEntry | null;
 };
 
-const ResponseView = ({ turn, fontsLoaded, onPlayAudio, isPlaying }: ResponseViewProps) => {
+const ResponseView = ({ turn, fontsLoaded, onPlayAudio, isPlaying, historyEntry }: ResponseViewProps) => {
   const frauncesItalic = fontsLoaded ? { fontFamily: FONT_FAMILIES.frauncesMediumItalic } : {};
   const notoSerif = fontsLoaded ? { fontFamily: FONT_FAMILIES.notoSerifMedium } : {};
   const spaceGrotesk = fontsLoaded ? { fontFamily: FONT_FAMILIES.spaceGroteskSemiBold } : {};
   const spaceGroteskBold = fontsLoaded ? { fontFamily: FONT_FAMILIES.spaceGroteskBold } : {};
   const breakdown = buildBreakdown(turn.chinese, turn.pinyin);
+  const { save: saveEntry, unsave: unsaveEntry, isSaved } = useSavedStore();
+  const saved = historyEntry ? isSaved(historyEntry.id) : false;
 
   return (
     <ScrollView
@@ -679,6 +683,14 @@ const ResponseView = ({ turn, fontsLoaded, onPlayAudio, isPlaying }: ResponseVie
         <Pressable style={styles.resSlowButton} onPress={() => onPlayAudio(true)}>
           <Text style={styles.resSlowButtonText}>½× SLOW</Text>
         </Pressable>
+        {historyEntry ? (
+          <Pressable
+            style={styles.resSaveButton}
+            onPress={() => saved ? unsaveEntry(historyEntry.id) : saveEntry(historyEntry, "GENERAL")}
+          >
+            <Text style={[styles.resSaveIcon, saved && styles.resSaveIconSaved]}>✦</Text>
+          </Pressable>
+        ) : null}
       </View>
 
       {/* 6. Horizontal rule */}
@@ -748,6 +760,7 @@ export default function App() {
   const [voiceError, setVoiceError] = useState<string | null>(null);
   const [showCantHear, setShowCantHear] = useState(false);
   const [voiceTurn, setVoiceTurn] = useState<SpeechTurnResponse | null>(null);
+  const [currentHistoryEntry, setCurrentHistoryEntry] = useState<HistoryEntry | null>(null);
   const [voiceHistory, setVoiceHistory] = useState<VoiceExchange[]>([]);
   const [showScenarioPicker, setShowScenarioPicker] = useState(false);
   const [selectedScenario, setSelectedScenario] = useState<PracticeScenario | null>(null);
@@ -1103,7 +1116,7 @@ export default function App() {
 
       const data = JSON.parse(raw) as SpeechTurnResponse;
       setVoiceTurn(data);
-      addHistoryEntry({
+      const entryA: HistoryEntry = {
         id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         timestamp: Date.now(),
         transcript: data.transcript || text,
@@ -1112,7 +1125,9 @@ export default function App() {
         english: data.assistant_text,
         notes: data.notes ?? [],
         audioUrl: data.audio_url ?? null,
-      });
+      };
+      addHistoryEntry(entryA);
+      setCurrentHistoryEntry(entryA);
       setVoiceHistory((previous) => [
         ...previous.slice(-2),
         {
@@ -1325,7 +1340,7 @@ export default function App() {
       }
 
       setVoiceTurn(data);
-      addHistoryEntry({
+      const entryB: HistoryEntry = {
         id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         timestamp: Date.now(),
         transcript: data.transcript,
@@ -1334,7 +1349,9 @@ export default function App() {
         english: data.assistant_text,
         notes: data.notes ?? [],
         audioUrl: data.audio_url ?? null,
-      });
+      };
+      addHistoryEntry(entryB);
+      setCurrentHistoryEntry(entryB);
       setVoiceHistory((previous) => [
         ...previous.slice(-2),
         {
@@ -1811,6 +1828,7 @@ export default function App() {
                 fontsLoaded={!!fontsLoaded}
                 onPlayAudio={(slow) => { void handleReplayAudio(slow); }}
                 isPlaying={isPlayingPronunciation}
+                historyEntry={currentHistoryEntry}
               />
             </Animated.View>
           ) : (
@@ -2678,6 +2696,22 @@ const styles = StyleSheet.create({
     fontSize: 11,
     letterSpacing: 1.2,
     color: TOKENS.ink,
+  },
+  resSaveButton: {
+    borderRadius: TOKENS.buttonRadius,
+    borderWidth: 1.5,
+    borderColor: TOKENS.ink,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  resSaveIcon: {
+    fontSize: 16,
+    color: TOKENS.inkFaint,
+  },
+  resSaveIconSaved: {
+    color: TOKENS.accent,
   },
   resRule: {
     height: 1,

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -535,6 +535,12 @@ const ListeningView = ({ liveTranscript, meteringLevel, fontsLoaded }: Listening
   const caretBlink = useRef(new Animated.Value(1)).current;
   const dotPulse = useRef(new Animated.Value(1)).current;
   const meteringRef = useRef(meteringLevel);
+  const [keepHolding, setKeepHolding] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => setKeepHolding(false), 800);
+    return () => clearTimeout(t);
+  }, []);
 
   useEffect(() => { meteringRef.current = meteringLevel; }, [meteringLevel]);
 
@@ -591,7 +597,7 @@ const ListeningView = ({ liveTranscript, meteringLevel, fontsLoaded }: Listening
             fontsLoaded ? { fontFamily: "Fraunces_500Medium_Italic" } : {},
           ]}
         >
-          {liveTranscript || "Listening…"}
+          {keepHolding ? "Keep holding…" : (liveTranscript || "Listening…")}
         </Text>
         <Animated.View style={[styles.transcriptCaret, { opacity: caretBlink }]} />
       </View>
@@ -1262,8 +1268,9 @@ export default function App() {
       const fileSize = "size" in fileInfo ? fileInfo.size : undefined;
       console.log("Voice recording duration (ms):", status.durationMillis);
       console.log("Voice recording file size (bytes):", fileSize);
-      if (!status.durationMillis || status.durationMillis < 200) {
-        throw new Error("Recording too short. Please hold the button longer.");
+      if (!status.durationMillis || status.durationMillis < 800) {
+        setShowCantHear(true);
+        return;
       }
       const formData = new FormData();
       formData.append("audio", {
@@ -1378,13 +1385,10 @@ export default function App() {
         voiceUploadError instanceof Error &&
         (voiceUploadError.name === "AbortError" ||
           errMsg.toLowerCase().includes("timed out"));
-      const isTooShort = errMsg.includes("Recording too short");
       setVoiceError(
-        isTooShort
-          ? errMsg
-          : isTimeout
-            ? "Voice request timed out. Please try again."
-            : "Voice request failed. Please try again."
+        isTimeout
+          ? "Voice request timed out. Please try again."
+          : "Voice request failed. Please try again."
       );
     } finally {
       userCancelledRef.current = false;

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -185,13 +185,6 @@ type SpeechTurnResponse = {
   transcript_confidence?: number;
 };
 
-type VoiceExchange = {
-  id: string;
-  userTranscript: string;
-  tutorChinese: string;
-  tutorPinyin: string;
-  tutorEnglish: string;
-};
 
 type PracticeScenario = {
   id: "ordering_food" | "taking_taxi" | "meeting_someone_new";
@@ -794,7 +787,6 @@ export default function App() {
   const [showCantHear, setShowCantHear] = useState(false);
   const [voiceTurn, setVoiceTurn] = useState<SpeechTurnResponse | null>(null);
   const [currentHistoryEntry, setCurrentHistoryEntry] = useState<HistoryEntry | null>(null);
-  const [voiceHistory, setVoiceHistory] = useState<VoiceExchange[]>([]);
   const [showScenarioPicker, setShowScenarioPicker] = useState(false);
   const [selectedScenario, setSelectedScenario] = useState<PracticeScenario | null>(null);
   const [selectedVoice, setSelectedVoice] = useState<VoiceOption>("warm");
@@ -949,7 +941,6 @@ export default function App() {
   const handleSwitchLanguage = async (next: SpeakerPreference) => {
     if (next === preference) return;
     setVoiceTurn(null);
-    setVoiceHistory([]);
     setShowTranslateError(false); setShowAudioError(false);
     setPreference(next);
     await AsyncStorage.setItem(STORAGE_KEY, next);
@@ -959,7 +950,6 @@ export default function App() {
     setSelectedScenario(scenario);
     setShowScenarioPicker(false);
     setVoiceTurn(null);
-    setVoiceHistory([]);
     setShowTranslateError(false); setShowAudioError(false);
   };
 
@@ -989,7 +979,6 @@ export default function App() {
   const handleLogout = async () => {
     await logout();
     setVoiceTurn(null);
-    setVoiceHistory([]);
     setShowTranslateError(false); setShowAudioError(false);
     setPreference(null);
     setIsLoadingPreference(true);
@@ -1165,16 +1154,6 @@ export default function App() {
       };
       addHistoryEntry(entryA);
       setCurrentHistoryEntry(entryA);
-      setVoiceHistory((previous) => [
-        ...previous.slice(-2),
-        {
-          id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-          userTranscript: text,
-          tutorChinese: data.chinese,
-          tutorPinyin: data.pinyin,
-          tutorEnglish: data.assistant_text,
-        },
-      ]);
       setShowVoiceComplete(true);
       if (completeTimeoutRef.current) clearTimeout(completeTimeoutRef.current);
       completeTimeoutRef.current = setTimeout(() => {
@@ -1384,16 +1363,6 @@ export default function App() {
       };
       addHistoryEntry(entryB);
       setCurrentHistoryEntry(entryB);
-      setVoiceHistory((previous) => [
-        ...previous.slice(-2),
-        {
-          id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-          userTranscript: data.transcript,
-          tutorChinese: data.chinese,
-          tutorPinyin: data.pinyin,
-          tutorEnglish: data.assistant_text,
-        },
-      ]);
       setShowVoiceComplete(true);
       if (completeTimeoutRef.current) {
         clearTimeout(completeTimeoutRef.current);
@@ -1760,88 +1729,6 @@ export default function App() {
           />
         ) : null}
         {activeTab === "SPEAK" && micPermission !== "denied" && !showCantHear && !showTranslateError ? <View style={styles.centerStage}>
-          <View style={styles.practiceScenarioWrap}>
-            <Pressable
-              style={[
-                styles.practiceScenarioButton,
-                {
-                  backgroundColor: activeTheme.surfaceTint,
-                  borderColor: activeTheme.surfaceBorder,
-                },
-              ]}
-              onPress={() => setShowScenarioPicker((previous) => !previous)}
-            >
-              <Text style={[styles.practiceScenarioButtonText, { color: activeTheme.titleText }]}>
-                {selectedScenario
-                  ? `Practice Scenario: ${selectedScenario.title}`
-                  : "Practice Scenario"}
-              </Text>
-              <Text style={[styles.practiceScenarioButtonHint, { color: activeTheme.subtitleText }]}>
-                {showScenarioPicker ? "Hide options" : "Choose a conversation context"}
-              </Text>
-            </Pressable>
-
-            {showScenarioPicker ? (
-              <View style={styles.practiceScenarioCards}>
-                {PRACTICE_SCENARIOS.map((scenario) => {
-                  const isActive = selectedScenario?.id === scenario.id;
-                  return (
-                    <Pressable
-                      key={scenario.id}
-                      style={[
-                        styles.practiceScenarioCard,
-                        {
-                          backgroundColor: activeTheme.surfaceTint,
-                          borderColor: activeTheme.surfaceBorder,
-                        },
-                        isActive && {
-                          borderColor: activeTheme.messageAccentText,
-                        },
-                      ]}
-                      onPress={() => handleSelectScenario(scenario)}
-                    >
-                      <Text style={[styles.practiceScenarioCardTitle, { color: activeTheme.titleText }]}>
-                        {scenario.title}
-                      </Text>
-                      <Text style={[styles.practiceScenarioCardDescription, { color: activeTheme.subtitleText }]}>
-                        {scenario.description}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-              </View>
-            ) : null}
-          </View>
-
-          {selectedScenario ? (
-            <View
-              style={[
-                styles.relevantVocabPanel,
-                {
-                  backgroundColor: activeTheme.surfaceTint,
-                  borderColor: activeTheme.surfaceBorder,
-                },
-              ]}
-            >
-              <Text style={[styles.relevantVocabTitle, { color: activeTheme.titleText }]}>
-                Relevant vocab · {selectedScenario.title}
-              </Text>
-              {selectedScenario.vocab.map((word) => (
-                <View key={`${selectedScenario.id}-${word.chinese}`} style={styles.relevantVocabRow}>
-                  <Text style={[styles.relevantVocabChinese, { color: activeTheme.titleText }]}>
-                    {word.chinese}
-                  </Text>
-                  <Text style={[styles.relevantVocabPinyin, { color: activeTheme.messageAccentText }]}>
-                    {word.pinyin}
-                  </Text>
-                  <Text style={[styles.relevantVocabEnglish, { color: activeTheme.subtitleText }]}>
-                    {word.english}
-                  </Text>
-                </View>
-              ))}
-            </View>
-          ) : null}
-
           {isRecording ? (
             <ListeningView
               liveTranscript={liveTranscript}
@@ -1948,71 +1835,6 @@ export default function App() {
             />
           </Animated.View>
 
-          {voiceHistory.length ? (
-            <View style={styles.voiceHistoryWrap}>
-              {voiceHistory.map((exchange) => (
-                <View
-                  key={exchange.id}
-                  style={[
-                    styles.voiceHistoryBubble,
-                    {
-                      backgroundColor: activeTheme.surfaceTint,
-                      borderColor: activeTheme.surfaceBorder,
-                    },
-                  ]}
-                >
-                  <Text
-                    style={[
-                      styles.voiceHistoryUserLabel,
-                      { color: activeTheme.voiceSupportText },
-                    ]}
-                  >
-                    You said
-                  </Text>
-                  <Text
-                    style={[
-                      styles.voiceHistoryUserText,
-                      { color: activeTheme.titleText },
-                    ]}
-                  >
-                    {exchange.userTranscript}
-                  </Text>
-                  <Text
-                    style={[
-                      styles.voiceHistoryTutorLabel,
-                      { color: activeTheme.voiceSupportText },
-                    ]}
-                  >
-                    Tutor replied
-                  </Text>
-                  <Text
-                    style={[
-                      styles.voiceHistoryTutorChinese,
-                      { color: activeTheme.titleText },
-                    ]}
-                  >
-                    {exchange.tutorChinese}
-                  </Text>
-                  <Text
-                    style={[
-                      styles.voiceHistoryTutorPinyin,
-                      { color: activeTheme.messageAccentText },
-                    ]}
-                  >
-                    {exchange.tutorPinyin}
-                  </Text>
-                  <Text
-                    style={[
-                      styles.voiceHistoryTutorEnglish,
-                      { color: activeTheme.subtitleText },
-                    ]}
-                  >
-                    {exchange.tutorEnglish}
-                  </Text>
-                </View>
-              ))}
-            </View>
-          ) : null}
         </View> : null}
       </KeyboardAvoidingView>
       <Modal
@@ -2023,18 +1845,98 @@ export default function App() {
       >
         <Pressable style={styles.drawerOverlay} onPress={() => setShowDrawer(false)}>
           <View style={styles.drawerPanel}>
-            {DEMO_MODE || CHATBOT_ONLY_MODE || !REQUIRE_AUTH ? (
-              <Text style={styles.drawerEmpty}>Settings coming soon</Text>
-            ) : (
-              <Pressable
-                onPress={() => {
-                  setShowDrawer(false);
-                  void handleLogout();
-                }}
+            <Text style={styles.drawerSectionLabel}>PRACTICE SCENARIO</Text>
+            <Pressable
+              style={[
+                styles.practiceScenarioButton,
+                {
+                  backgroundColor: activeTheme.surfaceTint,
+                  borderColor: activeTheme.surfaceBorder,
+                },
+              ]}
+              onPress={() => setShowScenarioPicker((previous) => !previous)}
+            >
+              <Text style={[styles.practiceScenarioButtonText, { color: activeTheme.titleText }]}>
+                {selectedScenario ? selectedScenario.title : "None selected"}
+              </Text>
+              <Text style={[styles.practiceScenarioButtonHint, { color: activeTheme.subtitleText }]}>
+                {showScenarioPicker ? "Hide options" : "Choose a conversation context"}
+              </Text>
+            </Pressable>
+
+            {showScenarioPicker ? (
+              <View style={styles.practiceScenarioCards}>
+                {PRACTICE_SCENARIOS.map((scenario) => {
+                  const isActive = selectedScenario?.id === scenario.id;
+                  return (
+                    <Pressable
+                      key={scenario.id}
+                      style={[
+                        styles.practiceScenarioCard,
+                        {
+                          backgroundColor: activeTheme.surfaceTint,
+                          borderColor: activeTheme.surfaceBorder,
+                        },
+                        isActive && {
+                          borderColor: activeTheme.messageAccentText,
+                        },
+                      ]}
+                      onPress={() => handleSelectScenario(scenario)}
+                    >
+                      <Text style={[styles.practiceScenarioCardTitle, { color: activeTheme.titleText }]}>
+                        {scenario.title}
+                      </Text>
+                      <Text style={[styles.practiceScenarioCardDescription, { color: activeTheme.subtitleText }]}>
+                        {scenario.description}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            ) : null}
+
+            {selectedScenario ? (
+              <View
+                style={[
+                  styles.relevantVocabPanel,
+                  {
+                    backgroundColor: activeTheme.surfaceTint,
+                    borderColor: activeTheme.surfaceBorder,
+                  },
+                ]}
               >
-                <Text style={styles.drawerItem}>Logout</Text>
-              </Pressable>
-            )}
+                <Text style={[styles.relevantVocabTitle, { color: activeTheme.titleText }]}>
+                  Vocab · {selectedScenario.title}
+                </Text>
+                {selectedScenario.vocab.map((word) => (
+                  <View key={`${selectedScenario.id}-${word.chinese}`} style={styles.relevantVocabRow}>
+                    <Text style={[styles.relevantVocabChinese, { color: activeTheme.titleText }]}>
+                      {word.chinese}
+                    </Text>
+                    <Text style={[styles.relevantVocabPinyin, { color: activeTheme.messageAccentText }]}>
+                      {word.pinyin}
+                    </Text>
+                    <Text style={[styles.relevantVocabEnglish, { color: activeTheme.subtitleText }]}>
+                      {word.english}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            ) : null}
+
+            {!DEMO_MODE && !CHATBOT_ONLY_MODE && REQUIRE_AUTH ? (
+              <>
+                <View style={styles.drawerDivider} />
+                <Pressable
+                  onPress={() => {
+                    setShowDrawer(false);
+                    void handleLogout();
+                  }}
+                >
+                  <Text style={styles.drawerItem}>Logout</Text>
+                </Pressable>
+              </>
+            ) : null}
           </View>
         </Pressable>
       </Modal>
@@ -2285,15 +2187,28 @@ const styles = StyleSheet.create({
     backgroundColor: "#FDFAF6",
     marginTop: 88,
     marginRight: 16,
+    marginLeft: 16,
     borderRadius: TOKENS.cardRadius,
-    paddingVertical: 12,
+    paddingVertical: 16,
     paddingHorizontal: 16,
-    minWidth: 180,
     shadowColor: "#000",
     shadowOpacity: 0.12,
     shadowRadius: 12,
     shadowOffset: { width: 0, height: 4 },
     elevation: 8,
+  },
+  drawerSectionLabel: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: TOKENS.inkFaint,
+    marginBottom: 10,
+  },
+  drawerDivider: {
+    height: 1,
+    backgroundColor: TOKENS.rule,
+    marginVertical: 12,
   },
   drawerItem: {
     fontSize: 15,
@@ -2548,50 +2463,6 @@ const styles = StyleSheet.create({
   },
   micStageWrap: {
     alignItems: "center",
-  },
-  voiceHistoryWrap: {
-    width: "100%",
-    marginTop: 14,
-    gap: 10,
-  },
-  voiceHistoryBubble: {
-    borderWidth: 1,
-    borderRadius: TOKENS.cardRadius,
-    paddingVertical: 12,
-    paddingHorizontal: 14,
-  },
-  voiceHistoryUserLabel: {
-    fontSize: 11,
-    fontWeight: "700",
-    textTransform: "uppercase",
-    letterSpacing: 0.5,
-  },
-  voiceHistoryUserText: {
-    fontSize: 14,
-    fontWeight: "600",
-    marginTop: 3,
-  },
-  voiceHistoryTutorLabel: {
-    fontSize: 11,
-    fontWeight: "700",
-    textTransform: "uppercase",
-    letterSpacing: 0.5,
-    marginTop: 10,
-  },
-  voiceHistoryTutorChinese: {
-    fontSize: 18,
-    fontWeight: "700",
-    marginTop: 4,
-  },
-  voiceHistoryTutorPinyin: {
-    fontSize: 14,
-    fontWeight: "600",
-    marginTop: 2,
-  },
-  voiceHistoryTutorEnglish: {
-    fontSize: 14,
-    lineHeight: 20,
-    marginTop: 2,
   },
   errorBanner: {
     backgroundColor: "#FEE2E2",

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -630,10 +630,11 @@ type ResponseViewProps = {
   fontsLoaded: boolean;
   onPlayAudio: (slow: boolean) => void;
   isPlaying: boolean;
+  isAudioPending: boolean;
   historyEntry: HistoryEntry | null;
 };
 
-const ResponseView = ({ turn, fontsLoaded, onPlayAudio, isPlaying, historyEntry }: ResponseViewProps) => {
+const ResponseView = ({ turn, fontsLoaded, onPlayAudio, isPlaying, isAudioPending, historyEntry }: ResponseViewProps) => {
   const frauncesItalic = fontsLoaded ? { fontFamily: FONT_FAMILIES.frauncesMediumItalic } : {};
   const notoSerif = fontsLoaded ? { fontFamily: FONT_FAMILIES.notoSerifMedium } : {};
   const spaceGrotesk = fontsLoaded ? { fontFamily: FONT_FAMILIES.spaceGroteskSemiBold } : {};
@@ -675,12 +676,23 @@ const ResponseView = ({ turn, fontsLoaded, onPlayAudio, isPlaying, historyEntry 
       {/* 5. Action row */}
       <View style={styles.resActionRow}>
         <Pressable
-          style={[styles.resPlayButton, isPlaying && styles.resPlayButtonActive]}
+          style={[
+            styles.resPlayButton,
+            isPlaying && styles.resPlayButtonActive,
+            isAudioPending && styles.resPlayButtonPending,
+          ]}
           onPress={() => onPlayAudio(false)}
+          disabled={isAudioPending || isPlaying}
         >
-          <Text style={styles.resPlayButtonText}>▶ PLAY AUDIO</Text>
+          <Text style={styles.resPlayButtonText}>
+            {isAudioPending ? "⋯ LOADING" : "▶ PLAY AUDIO"}
+          </Text>
         </Pressable>
-        <Pressable style={styles.resSlowButton} onPress={() => onPlayAudio(true)}>
+        <Pressable
+          style={[styles.resSlowButton, (isAudioPending || isPlaying) && styles.resSlowButtonDisabled]}
+          onPress={() => onPlayAudio(true)}
+          disabled={isAudioPending || isPlaying}
+        >
           <Text style={styles.resSlowButtonText}>½× SLOW</Text>
         </Pressable>
         {historyEntry ? (
@@ -755,6 +767,7 @@ export default function App() {
     useState<MicPermissionState>("undetermined");
   const [isRecording, setIsRecording] = useState(false);
   const [isUploadingVoice, setIsUploadingVoice] = useState(false);
+  const [isAudioPending, setIsAudioPending] = useState(false);
   const [isPlayingPronunciation, setIsPlayingPronunciation] = useState(false);
   const [showVoiceComplete, setShowVoiceComplete] = useState(false);
   const [voiceError, setVoiceError] = useState<string | null>(null);
@@ -1036,14 +1049,13 @@ export default function App() {
   };
 
   const pollForAudioJob = async (jobId: string) => {
+    setIsAudioPending(true);
     const maxAttempts = 10;
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       logApiBaseUrl(`Audio poll attempt ${attempt}`);
       const { response } = await apiFetchWithTimeout(
         `/v1/speech/audio/${jobId}`,
-        {
-          method: "GET",
-        },
+        { method: "GET" },
         30_000,
         0
       );
@@ -1051,6 +1063,7 @@ export default function App() {
       console.log("Audio poll status:", response.status);
       console.log("Audio poll response:", raw.slice(0, 500));
       if (!response.ok) {
+        setIsAudioPending(false);
         setVoiceError("Audio fetch failed. Please try again.");
         return;
       }
@@ -1068,18 +1081,22 @@ export default function App() {
           base64: data.audio_base64 ?? undefined,
         };
         if (audioPayload.url || audioPayload.base64) {
+          setIsAudioPending(false);
           await playVoiceAudio(audioPayload, data.audio_mime ?? undefined);
           return;
         }
+        setIsAudioPending(false);
         setVoiceError("Audio unavailable. Please try again.");
         return;
       }
       if (data.status === "error") {
+        setIsAudioPending(false);
         setVoiceError(data.tts_error ?? "Audio failed. Please try again.");
         return;
       }
       await wait(1000);
     }
+    setIsAudioPending(false);
     setVoiceError("Audio is taking too long. Please try again.");
   };
 
@@ -1828,6 +1845,7 @@ export default function App() {
                 fontsLoaded={!!fontsLoaded}
                 onPlayAudio={(slow) => { void handleReplayAudio(slow); }}
                 isPlaying={isPlayingPronunciation}
+                isAudioPending={isAudioPending}
                 historyEntry={currentHistoryEntry}
               />
             </Animated.View>
@@ -2676,6 +2694,9 @@ const styles = StyleSheet.create({
   resPlayButtonActive: {
     backgroundColor: "#3B3530",
   },
+  resPlayButtonPending: {
+    opacity: 0.5,
+  },
   resPlayButtonText: {
     fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
     fontSize: 11,
@@ -2690,6 +2711,9 @@ const styles = StyleSheet.create({
     borderColor: TOKENS.ink,
     paddingVertical: 12,
     alignItems: "center",
+  },
+  resSlowButtonDisabled: {
+    opacity: 0.35,
   },
   resSlowButtonText: {
     fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -625,6 +625,14 @@ const buildBreakdown = (chinese: string, pinyin: string): MorphemeEntry[] => {
 
 // ─── Response view ────────────────────────────────────────────────────────────
 
+const TONE_LEGEND = [
+  { tone: 1 as const, label: "1 flat" },
+  { tone: 2 as const, label: "2 rising" },
+  { tone: 3 as const, label: "3 dipping" },
+  { tone: 4 as const, label: "4 falling" },
+  { tone: 5 as const, label: "neutral" },
+];
+
 type ResponseViewProps = {
   turn: SpeechTurnResponse;
   fontsLoaded: boolean;
@@ -666,6 +674,15 @@ const ResponseView = ({ turn, fontsLoaded, onPlayAudio, isPlaying, isAudioPendin
         {turn.pinyin.trim().split(/\s+/).map((syllable, i) => (
           <Text key={i} style={[styles.resPinyinSyllable, spaceGroteskBold, { color: toneColor(syllable) }]}>
             {syllable}
+          </Text>
+        ))}
+      </View>
+
+      {/* 3b. Tone legend */}
+      <View style={styles.toneLegendRow}>
+        {TONE_LEGEND.map(({ tone, label }) => (
+          <Text key={tone} style={[styles.toneLegendItem, { color: getToneColor(tone) }]}>
+            ● {label}
           </Text>
         ))}
       </View>
@@ -2671,6 +2688,17 @@ const styles = StyleSheet.create({
   resPinyinSyllable: {
     fontSize: 16,
     fontWeight: "600",
+  },
+  toneLegendRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    marginBottom: 14,
+  },
+  toneLegendItem: {
+    fontFamily: Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" }),
+    fontSize: 9,
+    letterSpacing: 1.2,
   },
   resGloss: {
     fontSize: 17,

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -39,8 +39,10 @@ import { TOKENS, getToneColor, FONT_FAMILIES, detectTone, toneColor } from "./sr
 
 import ApiBlockedScreen from "./src/components/ApiBlockedScreen";
 import AuthScreen from "./src/components/AuthScreen";
+import AudioErrorCard from "./src/components/AudioErrorCard";
 import CantHearCard from "./src/components/CantHearCard";
 import MicDeniedCard from "./src/components/MicDeniedCard";
+import NetworkErrorCard from "./src/components/NetworkErrorCard";
 import HistoryScreen from "./src/components/HistoryScreen";
 import LockScreen from "./src/components/LockScreen";
 import SavedScreen from "./src/components/SavedScreen";
@@ -787,7 +789,8 @@ export default function App() {
   const [isAudioPending, setIsAudioPending] = useState(false);
   const [isPlayingPronunciation, setIsPlayingPronunciation] = useState(false);
   const [showVoiceComplete, setShowVoiceComplete] = useState(false);
-  const [voiceError, setVoiceError] = useState<string | null>(null);
+  const [showTranslateError, setShowTranslateError] = useState(false);
+  const [showAudioError, setShowAudioError] = useState(false);
   const [showCantHear, setShowCantHear] = useState(false);
   const [voiceTurn, setVoiceTurn] = useState<SpeechTurnResponse | null>(null);
   const [currentHistoryEntry, setCurrentHistoryEntry] = useState<HistoryEntry | null>(null);
@@ -947,7 +950,7 @@ export default function App() {
     if (next === preference) return;
     setVoiceTurn(null);
     setVoiceHistory([]);
-    setVoiceError(null);
+    setShowTranslateError(false); setShowAudioError(false);
     setPreference(next);
     await AsyncStorage.setItem(STORAGE_KEY, next);
   };
@@ -957,7 +960,7 @@ export default function App() {
     setShowScenarioPicker(false);
     setVoiceTurn(null);
     setVoiceHistory([]);
-    setVoiceError(null);
+    setShowTranslateError(false); setShowAudioError(false);
   };
 
   const handleLogin = async (username: string, password: string) => {
@@ -987,7 +990,7 @@ export default function App() {
     await logout();
     setVoiceTurn(null);
     setVoiceHistory([]);
-    setVoiceError(null);
+    setShowTranslateError(false); setShowAudioError(false);
     setPreference(null);
     setIsLoadingPreference(true);
     setIsAuthenticated(false);
@@ -1081,7 +1084,7 @@ export default function App() {
       console.log("Audio poll response:", raw.slice(0, 500));
       if (!response.ok) {
         setIsAudioPending(false);
-        setVoiceError("Audio fetch failed. Please try again.");
+        setShowAudioError(true);
         return;
       }
       const data = JSON.parse(raw) as {
@@ -1103,18 +1106,18 @@ export default function App() {
           return;
         }
         setIsAudioPending(false);
-        setVoiceError("Audio unavailable. Please try again.");
+        setShowAudioError(true);
         return;
       }
       if (data.status === "error") {
         setIsAudioPending(false);
-        setVoiceError(data.tts_error ?? "Audio failed. Please try again.");
+        setShowAudioError(true);
         return;
       }
       await wait(1000);
     }
     setIsAudioPending(false);
-    setVoiceError("Audio is taking too long. Please try again.");
+    setShowAudioError(true);
   };
 
   const handleTypeInsteadSubmit = async (text: string) => {
@@ -1122,7 +1125,7 @@ export default function App() {
     setShowCantHear(false);
     setIsUploadingVoice(true);
     setProcessingTranscript(text);
-    setVoiceError(null);
+    setShowTranslateError(false); setShowAudioError(false);
     try {
       const formData = new FormData();
       formData.append("text", text);
@@ -1189,12 +1192,12 @@ export default function App() {
         } catch (playbackError) {
           console.error("Playback error:", playbackError);
           setIsPlayingPronunciation(false);
-          setVoiceError("Audio playback failed. Please check your volume and try again.");
+          setShowAudioError(true);
         }
       } else if (data.audio_pending && data.audio_job_id) {
         await pollForAudioJob(data.audio_job_id);
       } else {
-        setVoiceError(data.tts_error ?? "Audio unavailable. Please try again.");
+        setShowAudioError(true);
       }
     } catch (err) {
       console.error("Type-instead error:", err);
@@ -1202,7 +1205,7 @@ export default function App() {
         setProcessingTranscript("");
         return;
       }
-      setVoiceError("Translation failed. Please try again.");
+      setShowTranslateError(true);
     } finally {
       userCancelledRef.current = false;
       voiceFetchControllerRef.current = null;
@@ -1253,19 +1256,14 @@ export default function App() {
       return;
     }
     const hasPermission = await ensureMicPermission();
-    if (!hasPermission) {
-      setVoiceError(
-        "Microphone access is required. Please enable it in system settings."
-      );
-      return;
-    }
+    if (!hasPermission) return;
     if (completeTimeoutRef.current) {
       clearTimeout(completeTimeoutRef.current);
       completeTimeoutRef.current = null;
     }
     setShowVoiceComplete(false);
     setShowCantHear(false);
-    setVoiceError(null);
+    setShowTranslateError(false); setShowAudioError(false);
     if (soundRef.current) {
       await soundRef.current.stopAsync();
       await soundRef.current.unloadAsync();
@@ -1301,7 +1299,7 @@ export default function App() {
     setIsUploadingVoice(true);
     setShowVoiceComplete(false);
     setIsPlayingPronunciation(false);
-    setVoiceError(null);
+    setShowTranslateError(false); setShowAudioError(false);
     setProcessingTranscript(liveTranscript);
     setLiveTranscript("");
     setMeteringLevel(-160);
@@ -1415,14 +1413,12 @@ export default function App() {
         } catch (playbackError) {
           console.error("Voice playback error:", playbackError);
           setIsPlayingPronunciation(false);
-          setVoiceError(
-            "Audio playback failed. Please check your volume and try again."
-          );
+          setShowAudioError(true);
         }
       } else if (data.audio_pending && data.audio_job_id) {
         await pollForAudioJob(data.audio_job_id);
       } else {
-        setVoiceError(data.tts_error ?? "Audio unavailable. Please try again.");
+        setShowAudioError(true);
       }
     } catch (voiceUploadError) {
       console.error("Voice upload error:", voiceUploadError);
@@ -1436,11 +1432,7 @@ export default function App() {
         voiceUploadError instanceof Error &&
         (voiceUploadError.name === "AbortError" ||
           errMsg.toLowerCase().includes("timed out"));
-      setVoiceError(
-        isTimeout
-          ? "Voice request timed out. Please try again."
-          : "Voice request failed. Please try again."
-      );
+      setShowTranslateError(true);
     } finally {
       userCancelledRef.current = false;
       voiceFetchControllerRef.current = null;
@@ -1736,9 +1728,9 @@ export default function App() {
           </View>
         </Animated.View>
 
-        {error || voiceError ? (
+        {error ? (
           <View style={styles.errorBanner}>
-            <Text style={styles.errorText}>{voiceError ?? error}</Text>
+            <Text style={styles.errorText}>{error}</Text>
           </View>
         ) : null}
 
@@ -1760,7 +1752,14 @@ export default function App() {
             onTypeInsteadSubmit={(text) => { void handleTypeInsteadSubmit(text); }}
           />
         ) : null}
-        {activeTab === "SPEAK" && micPermission !== "denied" && !showCantHear ? <View style={styles.centerStage}>
+        {activeTab === "SPEAK" && micPermission !== "denied" && showTranslateError ? (
+          <NetworkErrorCard
+            fontsLoaded={!!fontsLoaded}
+            onTryAgain={() => setShowTranslateError(false)}
+            onTypeInsteadSubmit={(text) => { void handleTypeInsteadSubmit(text); }}
+          />
+        ) : null}
+        {activeTab === "SPEAK" && micPermission !== "denied" && !showCantHear && !showTranslateError ? <View style={styles.centerStage}>
           <View style={styles.practiceScenarioWrap}>
             <Pressable
               style={[
@@ -1854,6 +1853,11 @@ export default function App() {
               processingTranscript={processingTranscript}
               fontsLoaded={!!fontsLoaded}
               onCancel={handleCancelTranslation}
+            />
+          ) : voiceTurn && showAudioError ? (
+            <AudioErrorCard
+              fontsLoaded={!!fontsLoaded}
+              onShowText={() => setShowAudioError(false)}
             />
           ) : voiceTurn ? (
             <Animated.View style={{ opacity: responseFade, alignSelf: "stretch" }}>

--- a/mobile/src/components/AudioErrorCard.tsx
+++ b/mobile/src/components/AudioErrorCard.tsx
@@ -1,0 +1,89 @@
+import {
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+
+import { FONT_FAMILIES, TOKENS } from "../styles/tokens";
+
+type Props = {
+  fontsLoaded: boolean;
+  onShowText: () => void;
+};
+
+const AudioErrorCard = ({ fontsLoaded, onShowText }: Props) => {
+  const frauncesMedItalic = fontsLoaded
+    ? { fontFamily: FONT_FAMILIES.frauncesMediumItalic }
+    : {};
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.textBlock}>
+        <Text style={styles.eyebrow}>— AUDIO UNAVAILABLE</Text>
+        <Text style={[styles.headline, frauncesMedItalic]}>
+          We have your translation.
+        </Text>
+        <Text style={styles.body}>
+          The audio couldn't be generated, but your translation is ready to read.
+        </Text>
+      </View>
+
+      <Pressable style={styles.primaryBtn} onPress={onShowText}>
+        <Text style={styles.primaryBtnText}>SHOW TEXT</Text>
+      </Pressable>
+    </View>
+  );
+};
+
+const MONO = Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" });
+
+const styles = StyleSheet.create({
+  wrap: {
+    flex: 1,
+    paddingHorizontal: 28,
+    paddingBottom: 36,
+    justifyContent: "space-between",
+  },
+  textBlock: {
+    flex: 1,
+    justifyContent: "center",
+    paddingBottom: 20,
+  },
+  eyebrow: {
+    fontFamily: MONO,
+    fontSize: 11,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: TOKENS.inkFaint,
+    marginBottom: 18,
+  },
+  headline: {
+    fontSize: 30,
+    lineHeight: 36,
+    fontStyle: "italic",
+    color: TOKENS.ink,
+    marginBottom: 16,
+  },
+  body: {
+    fontSize: 14,
+    lineHeight: 22,
+    color: TOKENS.inkSoft,
+  },
+  primaryBtn: {
+    backgroundColor: TOKENS.ink,
+    borderRadius: TOKENS.buttonRadius,
+    paddingVertical: 15,
+    alignItems: "center",
+  },
+  primaryBtnText: {
+    fontFamily: MONO,
+    fontSize: 12,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: "#FFFFFF",
+  },
+});
+
+export default AudioErrorCard;

--- a/mobile/src/components/AuthScreen.tsx
+++ b/mobile/src/components/AuthScreen.tsx
@@ -9,6 +9,8 @@ import {
   View,
 } from "react-native";
 
+import { TOKENS } from "../styles/tokens";
+
 type AuthScreenProps = {
   onSubmit: (username: string, password: string) => void;
   isSubmitting: boolean;
@@ -74,7 +76,7 @@ const styles = StyleSheet.create({
   },
   card: {
     backgroundColor: "#FFFFFF",
-    borderRadius: 16,
+    borderRadius: TOKENS.cardRadius,
     padding: 24,
     width: "100%",
     maxWidth: 420,
@@ -104,7 +106,7 @@ const styles = StyleSheet.create({
   button: {
     marginTop: 16,
     paddingVertical: 12,
-    borderRadius: 16,
+    borderRadius: TOKENS.buttonRadius,
     backgroundColor: "#2F6FED",
     alignItems: "center",
   },

--- a/mobile/src/components/CantHearCard.tsx
+++ b/mobile/src/components/CantHearCard.tsx
@@ -138,7 +138,7 @@ const styles = StyleSheet.create({
   },
   primaryBtn: {
     backgroundColor: TOKENS.ink,
-    borderRadius: 2,
+    borderRadius: TOKENS.buttonRadius,
     paddingVertical: 15,
     alignItems: "center",
   },
@@ -150,7 +150,7 @@ const styles = StyleSheet.create({
     color: "#FFFFFF",
   },
   secondaryBtn: {
-    borderRadius: 2,
+    borderRadius: TOKENS.buttonRadius,
     borderWidth: 1.5,
     borderColor: TOKENS.ink,
     paddingVertical: 15,
@@ -200,7 +200,7 @@ const styles = StyleSheet.create({
   },
   sheetSubmitBtn: {
     backgroundColor: TOKENS.ink,
-    borderRadius: 2,
+    borderRadius: TOKENS.buttonRadius,
     paddingVertical: 14,
     alignItems: "center",
   },

--- a/mobile/src/components/LockScreen.tsx
+++ b/mobile/src/components/LockScreen.tsx
@@ -10,6 +10,7 @@ import {
 } from "react-native";
 
 import { getAppPassword } from "../config/appLock";
+import { TOKENS } from "../styles/tokens";
 
 type LockScreenProps = {
   onUnlock: () => Promise<void> | void;
@@ -82,7 +83,7 @@ const styles = StyleSheet.create({
     width: "100%",
     maxWidth: 420,
     backgroundColor: "#FFFFFF",
-    borderRadius: 20,
+    borderRadius: TOKENS.cardRadius,
     padding: 24,
     shadowColor: "#000000",
     shadowOpacity: 0.12,
@@ -119,7 +120,7 @@ const styles = StyleSheet.create({
     marginTop: 20,
     backgroundColor: "#2563EB",
     paddingVertical: 12,
-    borderRadius: 16,
+    borderRadius: TOKENS.buttonRadius,
     alignItems: "center",
   },
   buttonDisabled: {

--- a/mobile/src/components/MicDeniedCard.tsx
+++ b/mobile/src/components/MicDeniedCard.tsx
@@ -1,0 +1,219 @@
+import { useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Linking,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import { FONT_FAMILIES, TOKENS } from "../styles/tokens";
+
+type Props = {
+  fontsLoaded: boolean;
+  onTypeInsteadSubmit: (text: string) => void;
+};
+
+const MicDeniedCard = ({ fontsLoaded, onTypeInsteadSubmit }: Props) => {
+  const [showSheet, setShowSheet] = useState(false);
+  const [input, setInput] = useState("");
+
+  const frauncesMedItalic = fontsLoaded
+    ? { fontFamily: FONT_FAMILIES.frauncesMediumItalic }
+    : {};
+  const frauncesRegItalic = fontsLoaded
+    ? { fontFamily: FONT_FAMILIES.frauncesRegularItalic }
+    : {};
+
+  const submit = () => {
+    const text = input.trim();
+    if (!text) return;
+    setInput("");
+    setShowSheet(false);
+    onTypeInsteadSubmit(text);
+  };
+
+  return (
+    <View style={styles.wrap}>
+      {/* ── Text content ─────────────────────────────────── */}
+      <View style={styles.textBlock}>
+        <Text style={styles.eyebrow}>— MIC ACCESS NEEDED</Text>
+        <Text style={[styles.headline, frauncesMedItalic]}>
+          Allow microphone access to start speaking.
+        </Text>
+        <Text style={styles.body}>
+          Chinese Tutor needs mic access to hear you. It's used only while
+          you're holding the button.
+        </Text>
+      </View>
+
+      {/* ── Action buttons ───────────────────────────────── */}
+      <View style={styles.buttons}>
+        <Pressable style={styles.primaryBtn} onPress={() => void Linking.openSettings()}>
+          <Text style={styles.primaryBtnText}>OPEN SETTINGS</Text>
+        </Pressable>
+        <Pressable style={styles.secondaryBtn} onPress={() => setShowSheet(true)}>
+          <Text style={styles.secondaryBtnText}>TYPE INSTEAD</Text>
+        </Pressable>
+      </View>
+
+      {/* ── Type Instead bottom sheet ─────────────────────── */}
+      <Modal
+        visible={showSheet}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowSheet(false)}
+      >
+        <KeyboardAvoidingView
+          style={styles.sheetOuter}
+          behavior={Platform.OS === "ios" ? "padding" : "height"}
+        >
+          <Pressable style={StyleSheet.absoluteFillObject} onPress={() => setShowSheet(false)} />
+          <View style={styles.sheetPanel}>
+            <Text style={styles.sheetEyebrow}>WHAT DID YOU WANT TO SAY?</Text>
+            <TextInput
+              style={[styles.sheetInput, frauncesRegItalic]}
+              value={input}
+              onChangeText={setInput}
+              placeholder="e.g. How do I order coffee?"
+              placeholderTextColor={TOKENS.inkFaint}
+              autoFocus
+              returnKeyType="send"
+              onSubmitEditing={submit}
+            />
+            <Pressable
+              style={[styles.sheetSubmitBtn, !input.trim() && styles.sheetSubmitBtnDisabled]}
+              onPress={submit}
+              disabled={!input.trim()}
+            >
+              <Text style={styles.sheetSubmitText}>TRANSLATE →</Text>
+            </Pressable>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+    </View>
+  );
+};
+
+const MONO = Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" });
+
+const styles = StyleSheet.create({
+  wrap: {
+    flex: 1,
+    paddingHorizontal: 28,
+    paddingBottom: 36,
+    justifyContent: "space-between",
+  },
+  textBlock: {
+    flex: 1,
+    justifyContent: "center",
+    paddingBottom: 20,
+  },
+  eyebrow: {
+    fontFamily: MONO,
+    fontSize: 11,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: TOKENS.accent,
+    marginBottom: 18,
+  },
+  headline: {
+    fontSize: 30,
+    lineHeight: 36,
+    fontStyle: "italic",
+    color: TOKENS.ink,
+    marginBottom: 16,
+  },
+  body: {
+    fontSize: 14,
+    lineHeight: 22,
+    color: TOKENS.inkSoft,
+  },
+  buttons: {
+    gap: 10,
+  },
+  primaryBtn: {
+    backgroundColor: TOKENS.ink,
+    borderRadius: 2,
+    paddingVertical: 15,
+    alignItems: "center",
+  },
+  primaryBtnText: {
+    fontFamily: MONO,
+    fontSize: 12,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: "#FFFFFF",
+  },
+  secondaryBtn: {
+    borderRadius: 2,
+    borderWidth: 1.5,
+    borderColor: TOKENS.ink,
+    paddingVertical: 15,
+    alignItems: "center",
+  },
+  secondaryBtnText: {
+    fontFamily: MONO,
+    fontSize: 12,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: TOKENS.ink,
+  },
+  // ── Sheet ────────────────────────────────────────────────────
+  sheetOuter: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  sheetPanel: {
+    backgroundColor: TOKENS.bgCard,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingHorizontal: 24,
+    paddingTop: 24,
+    paddingBottom: Platform.OS === "ios" ? 44 : 28,
+    shadowColor: "#000",
+    shadowOpacity: 0.14,
+    shadowRadius: 20,
+    shadowOffset: { width: 0, height: -4 },
+    elevation: 10,
+  },
+  sheetEyebrow: {
+    fontFamily: MONO,
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: TOKENS.inkFaint,
+    marginBottom: 16,
+  },
+  sheetInput: {
+    fontSize: 20,
+    fontStyle: "italic",
+    color: TOKENS.ink,
+    borderBottomWidth: 1.5,
+    borderBottomColor: TOKENS.ruleStrong,
+    paddingVertical: 10,
+    marginBottom: 20,
+  },
+  sheetSubmitBtn: {
+    backgroundColor: TOKENS.ink,
+    borderRadius: 2,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+  sheetSubmitBtnDisabled: {
+    opacity: 0.35,
+  },
+  sheetSubmitText: {
+    fontFamily: MONO,
+    fontSize: 12,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: "#FFFFFF",
+  },
+});
+
+export default MicDeniedCard;

--- a/mobile/src/components/MicDeniedCard.tsx
+++ b/mobile/src/components/MicDeniedCard.tsx
@@ -138,7 +138,7 @@ const styles = StyleSheet.create({
   },
   primaryBtn: {
     backgroundColor: TOKENS.ink,
-    borderRadius: 2,
+    borderRadius: TOKENS.buttonRadius,
     paddingVertical: 15,
     alignItems: "center",
   },
@@ -150,7 +150,7 @@ const styles = StyleSheet.create({
     color: "#FFFFFF",
   },
   secondaryBtn: {
-    borderRadius: 2,
+    borderRadius: TOKENS.buttonRadius,
     borderWidth: 1.5,
     borderColor: TOKENS.ink,
     paddingVertical: 15,
@@ -200,7 +200,7 @@ const styles = StyleSheet.create({
   },
   sheetSubmitBtn: {
     backgroundColor: TOKENS.ink,
-    borderRadius: 2,
+    borderRadius: TOKENS.buttonRadius,
     paddingVertical: 14,
     alignItems: "center",
   },

--- a/mobile/src/components/NetworkErrorCard.tsx
+++ b/mobile/src/components/NetworkErrorCard.tsx
@@ -1,0 +1,214 @@
+import { useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import { FONT_FAMILIES, TOKENS } from "../styles/tokens";
+
+type Props = {
+  fontsLoaded: boolean;
+  onTryAgain: () => void;
+  onTypeInsteadSubmit: (text: string) => void;
+};
+
+const NetworkErrorCard = ({ fontsLoaded, onTryAgain, onTypeInsteadSubmit }: Props) => {
+  const [showSheet, setShowSheet] = useState(false);
+  const [input, setInput] = useState("");
+
+  const frauncesMedItalic = fontsLoaded
+    ? { fontFamily: FONT_FAMILIES.frauncesMediumItalic }
+    : {};
+  const frauncesRegItalic = fontsLoaded
+    ? { fontFamily: FONT_FAMILIES.frauncesRegularItalic }
+    : {};
+
+  const submit = () => {
+    const text = input.trim();
+    if (!text) return;
+    setInput("");
+    setShowSheet(false);
+    onTypeInsteadSubmit(text);
+  };
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.textBlock}>
+        <Text style={styles.eyebrow}>— COULDN'T CONNECT</Text>
+        <Text style={[styles.headline, frauncesMedItalic]}>
+          The server took too long to respond.
+        </Text>
+        <Text style={styles.body}>
+          Check your connection and try again, or type your phrase instead.
+        </Text>
+      </View>
+
+      <View style={styles.buttons}>
+        <Pressable style={styles.primaryBtn} onPress={onTryAgain}>
+          <Text style={styles.primaryBtnText}>TRY AGAIN</Text>
+        </Pressable>
+        <Pressable style={styles.secondaryBtn} onPress={() => setShowSheet(true)}>
+          <Text style={styles.secondaryBtnText}>TYPE INSTEAD</Text>
+        </Pressable>
+      </View>
+
+      <Modal
+        visible={showSheet}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowSheet(false)}
+      >
+        <KeyboardAvoidingView
+          style={styles.sheetOuter}
+          behavior={Platform.OS === "ios" ? "padding" : "height"}
+        >
+          <Pressable style={StyleSheet.absoluteFillObject} onPress={() => setShowSheet(false)} />
+          <View style={styles.sheetPanel}>
+            <Text style={styles.sheetEyebrow}>WHAT DID YOU WANT TO SAY?</Text>
+            <TextInput
+              style={[styles.sheetInput, frauncesRegItalic]}
+              value={input}
+              onChangeText={setInput}
+              placeholder="e.g. How do I order coffee?"
+              placeholderTextColor={TOKENS.inkFaint}
+              autoFocus
+              returnKeyType="send"
+              onSubmitEditing={submit}
+            />
+            <Pressable
+              style={[styles.sheetSubmitBtn, !input.trim() && styles.sheetSubmitBtnDisabled]}
+              onPress={submit}
+              disabled={!input.trim()}
+            >
+              <Text style={styles.sheetSubmitText}>TRANSLATE →</Text>
+            </Pressable>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+    </View>
+  );
+};
+
+const MONO = Platform.select({ ios: "Courier New", android: "monospace", default: "monospace" });
+
+const styles = StyleSheet.create({
+  wrap: {
+    flex: 1,
+    paddingHorizontal: 28,
+    paddingBottom: 36,
+    justifyContent: "space-between",
+  },
+  textBlock: {
+    flex: 1,
+    justifyContent: "center",
+    paddingBottom: 20,
+  },
+  eyebrow: {
+    fontFamily: MONO,
+    fontSize: 11,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: TOKENS.inkFaint,
+    marginBottom: 18,
+  },
+  headline: {
+    fontSize: 30,
+    lineHeight: 36,
+    fontStyle: "italic",
+    color: TOKENS.ink,
+    marginBottom: 16,
+  },
+  body: {
+    fontSize: 14,
+    lineHeight: 22,
+    color: TOKENS.inkSoft,
+  },
+  buttons: {
+    gap: 10,
+  },
+  primaryBtn: {
+    backgroundColor: TOKENS.ink,
+    borderRadius: TOKENS.buttonRadius,
+    paddingVertical: 15,
+    alignItems: "center",
+  },
+  primaryBtnText: {
+    fontFamily: MONO,
+    fontSize: 12,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: "#FFFFFF",
+  },
+  secondaryBtn: {
+    borderRadius: TOKENS.buttonRadius,
+    borderWidth: 1.5,
+    borderColor: TOKENS.ink,
+    paddingVertical: 15,
+    alignItems: "center",
+  },
+  secondaryBtnText: {
+    fontFamily: MONO,
+    fontSize: 12,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: TOKENS.ink,
+  },
+  sheetOuter: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  sheetPanel: {
+    backgroundColor: TOKENS.bgCard,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingHorizontal: 24,
+    paddingTop: 24,
+    paddingBottom: Platform.OS === "ios" ? 44 : 28,
+    shadowColor: "#000",
+    shadowOpacity: 0.14,
+    shadowRadius: 20,
+    shadowOffset: { width: 0, height: -4 },
+    elevation: 10,
+  },
+  sheetEyebrow: {
+    fontFamily: MONO,
+    fontSize: 10,
+    letterSpacing: 1.6,
+    textTransform: "uppercase",
+    color: TOKENS.inkFaint,
+    marginBottom: 16,
+  },
+  sheetInput: {
+    fontSize: 20,
+    fontStyle: "italic",
+    color: TOKENS.ink,
+    borderBottomWidth: 1.5,
+    borderBottomColor: TOKENS.ruleStrong,
+    paddingVertical: 10,
+    marginBottom: 20,
+  },
+  sheetSubmitBtn: {
+    backgroundColor: TOKENS.ink,
+    borderRadius: TOKENS.buttonRadius,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+  sheetSubmitBtnDisabled: {
+    opacity: 0.35,
+  },
+  sheetSubmitText: {
+    fontFamily: MONO,
+    fontSize: 12,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: "#FFFFFF",
+  },
+});
+
+export default NetworkErrorCard;

--- a/mobile/src/config/apiClient.ts
+++ b/mobile/src/config/apiClient.ts
@@ -41,11 +41,14 @@ export const apiFetchWithTimeout = async (
   path: string,
   options: RequestInit,
   timeoutMs: number,
-  retryCount: number
+  retryCount: number,
+  externalSignal?: AbortSignal
 ) => {
   for (let attempt = 0; attempt <= retryCount; attempt += 1) {
+    if (externalSignal?.aborted) throw new DOMException("Aborted", "AbortError");
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    externalSignal?.addEventListener("abort", () => controller.abort(), { once: true });
     try {
       const response = await apiFetch(
         path,
@@ -56,6 +59,7 @@ export const apiFetchWithTimeout = async (
       return { response };
     } catch (error) {
       clearTimeout(timeoutId);
+      if (externalSignal?.aborted) throw error;
       const isTimeout =
         error instanceof Error && error.name === "AbortError";
       const isNetworkError =

--- a/mobile/src/styles/tokens.ts
+++ b/mobile/src/styles/tokens.ts
@@ -8,6 +8,8 @@ export const TOKENS = {
   accentSoft: "#E3EADD",
   rule: "rgba(21,17,13,0.12)",
   ruleStrong: "rgba(21,17,13,0.22)",
+  buttonRadius: 2,
+  cardRadius: 16,
   tones: {
     t1: "#B44637",
     t2: "#3E7A3C",


### PR DESCRIPTION
## Summary

Full resolution of the 10-issue heuristic audit against the V2 redesign. Each change targets exactly the gap identified in the issue — no extra scope.

- **#63** Suggestion chips now call `handleTypeInsteadSubmit` directly → one tap, instant translation; `pendingQuery` / "SAY SOMETHING LIKE" strip removed
- **#67** `micPermission === "denied"` renders `MicDeniedCard` (warm card) instead of a banner; primary CTA calls `Linking.openSettings()`; app re-checks permission on foreground via `AppState` listener
- **#61** Added `TOKENS.buttonRadius: 2` and `TOKENS.cardRadius: 16`; all hard-coded `borderRadius` values on buttons and cards replaced across `App.tsx`, `CantHearCard`, `MicDeniedCard`, `AuthScreen`, `LockScreen`
- **#62** Client-side recording minimum raised 200 ms → 800 ms; "Keep holding…" cue shown for the first 800 ms of recording inside `ListeningView`; sub-threshold releases go directly to `CantHearCard` (no API round-trip)
- **#64** `✦` save/unsave toggle added to `ResponseView` action row; calls `useSavedStore` directly; filled accent green when saved, outline when not; persists immediately to SAVED tab
- **#58** `isAudioPending` prop on `ResponseView`; PLAY AUDIO shows "⋯ LOADING" and is disabled while `pollForAudioJob` runs; re-enables automatically on poll resolution
- **#59** Tone-colour legend strip (`● 1 flat  ● 2 rising  ● 3 dipping  ● 4 falling  ● neutral`) added between pinyin row and gloss in `ResponseView`; uses exact `getToneColor` values
- **#66** Replaced `voiceError: string | null` banner with two warm error cards: `NetworkErrorCard` (TRY AGAIN + TYPE INSTEAD) for translate/timeout failures and `AudioErrorCard` (SHOW TEXT) for TTS failures; SHOW TEXT reveals `ResponseView` with the existing `voiceTurn`
- **#60** ✕ CANCEL link added to `ProcessingView`; calls `abortController.abort()` via an `externalSignal` prop threaded into `apiFetchWithTimeout`; returns to idle with no error toast
- **#65** SPEAK tab decluttered: Practice Scenario picker and vocab panel moved into the ≡ drawer; voice history bubbles removed entirely (data already lives in HISTORY tab); `VoiceExchange` type and `voiceHistory` state fully deleted; SPEAK default view is now daily phrase card + mic button only

## Test plan

- [ ] Tap a suggestion chip → `ProcessingView` appears immediately, no mic needed
- [ ] Revoke mic permission → `MicDeniedCard` appears; tap OPEN SETTINGS → device settings open; grant permission → card dismisses on return
- [ ] Hold mic button < 800 ms → `CantHearCard` shown, no network request fired
- [ ] Hold mic button → "Keep holding…" label visible for first ~800 ms
- [ ] Successful translation → ✦ button on action row; tap saves to SAVED tab; tap again unsaves
- [ ] `audio_pending: true` response → PLAY AUDIO shows "⋯ LOADING" until poll resolves
- [ ] Every tone colour in pinyin row has a matching entry in the legend strip below
- [ ] Simulate network timeout → `NetworkErrorCard` appears with TRY AGAIN + TYPE INSTEAD
- [ ] Simulate TTS failure → `AudioErrorCard` appears; tap SHOW TEXT → `ResponseView` visible
- [ ] Start translation, tap ✕ CANCEL → returns to idle instantly, no error shown
- [ ] SPEAK tab default state: only daily phrase card + mic button visible (no scenario widget, no history bubbles)
- [ ] Open ≡ drawer → Practice Scenario picker present and functional

https://claude.ai/code/session_01HLuyjh7NfoNKsHKiThcRvC

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLuyjh7NfoNKsHKiThcRvC)_